### PR TITLE
More robust finding of dmake.yml files

### DIFF
--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -90,7 +90,8 @@ def look_for_changed_directories():
 ###############################################################################
 
 def load_dmake_files_list():
-    build_files = common.run_shell_command("find . -name dmake.yml").split("\n")
+    # Ignore permission issues when searching for dmake.yml files, in a portable way
+    build_files = common.run_shell_command("{ LC_ALL=C find . -name dmake.yml 3>&2 2>&1 1>&3 | { grep -v 'Permission denied' >&3; [ $? -eq 1 ]; } } 3>&2 2>&1").split("\n")
     build_files = filter(lambda f: len(f.strip()) > 0, build_files)
     build_files = [file[2:] for file in build_files]
     # Important: for black listed files: we load file in order from root to deepest file


### PR DESCRIPTION
App build may generate files or directories only readable by root, in
which case dmake fails early:
```
Traceback (most recent call last):
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/dmake", line 73, in <module>
    core.make(root_dir, sub_dir, command, app, options)
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/core.py", line 495, in make
    build_files = load_dmake_files_list()
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/core.py", line 93, in load_dmake_files_list
    build_files = common.run_shell_command("find . -name dmake.yml").split("\n")
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/common.py", line 33, in run_shell_command
    raise ShellError(stderr)
deepomatic.dmake.common.ShellError: find: ‘./buffers/generated/python/buffers/flatbuf’: Permission denied
```

Fixed by ignoring permissions issues when finding the dmake.yml files.

There is no easy cross-platform solution to ignore permissions issues,
see https://stackoverflow.com/a/40336333