### PR TITLE
Fix python2 string decoding issue on stderr ShellException

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -11,6 +11,13 @@ logger.addHandler(logging.StreamHandler())
 
 ###############################################################################
 
+if sys.version_info >= (3,0):
+    from deepomatic.dmake.python_3x import is_string, read_input, subprocess_output_to_string
+else:
+    from deepomatic.dmake.python_2x import is_string, read_input, subprocess_output_to_string
+
+###############################################################################
+
 class ShellError(Exception):
     def __init__(self, msg):
         super(ShellError, self).__init__(msg)
@@ -30,8 +37,8 @@ def run_shell_command(cmd, ignore_error = False):
     p = subprocess.Popen(command, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     stdout, stderr = p.communicate()
     if len(stderr) > 0 and not ignore_error:
-        raise ShellError(stderr.decode())
-    return stdout.strip().decode()
+        raise ShellError(subprocess_output_to_string(stderr))
+    return subprocess_output_to_string(stdout).strip()
 
 def array_to_env_vars(array):
     return '#@#'.join([a.replace("@", "\\@") for a in array])
@@ -93,13 +100,6 @@ def pull_config_dir(root_dir):
     logger.info("Pulling config from: %s" % root_dir)
     os.system("cd %s && git pull origin master" % root_dir)
     pulled_config_dirs[root_dir] = True
-
-###############################################################################
-
-if sys.version_info >= (3,0):
-    from deepomatic.dmake.python_3x import is_string, read_input
-else:
-    from deepomatic.dmake.python_2x import is_string, read_input
 
 ###############################################################################
 

--- a/deepomatic/dmake/python_2x.py
+++ b/deepomatic/dmake/python_2x.py
@@ -6,3 +6,7 @@ def is_string(x):
 
 def read_input(msg):
     return raw_input(msg + ' ')
+
+def subprocess_output_to_string(output):
+    """Returns a python 2 str (bytes characters string)"""
+    return output

--- a/deepomatic/dmake/python_3x.py
+++ b/deepomatic/dmake/python_3x.py
@@ -21,3 +21,7 @@ def is_string(x):
 
 def read_input(msg):
     return input(msg + ' ')
+
+def subprocess_output_to_string(output):
+    """Returns a python 3 string (unicode characters string) from a 'bytes' object"""
+    return output.decode()


### PR DESCRIPTION
With python2 `run_shell_command` previously failed to raise
`ShellError(stderr.decode())` in case of error:

```
Traceback (most recent call last):
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/dmake", line 73, in <module>
    core.make(root_dir, sub_dir, command, app, options)
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/core.py", line 495, in make
    build_files = load_dmake_files_list()
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/core.py", line 93, in load_dmake_files_list
    build_files = common.run_shell_command("find . -name dmake.yml").split("\n")
  File "/home/thomas/deepomatic/dmake/deepomatic/dmake/common.py", line 33, in run_shell_command
    raise ShellError(stderr.decode())
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 6: ordinal not in range(128)
```

This happened because in python2 `subprocess` already returns a `str`,
and the decoding into `unicode` using the default `ascii` encoding, but `str` really
is `UTF-8`-encoded.
In fact we don't want to decode it from `UTF-8` because the `raise
ShellError(stderr)` then converts it back from `unicode` to `str`
using the default `ascii` encoding, which would fail for the same
reason.

So for python2 we just want to keep the raw `str` from
`p.communicate()`, at least for raising the exception.

As for the normal output of `run_shell_command`, we change the type
from `unicode` to `str` for consistency:
the previous version would not work when the shell output contained
non-`ascii` characters:

```
>>> run_shell_command("echo tést")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 7, in run_shell_command
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1: ordinal not in range(128)
```

The output type change hopefully doesn't change anything, because in
the working scenarii the `unicode` object and `ascii`-encoded `str`
object were identical (it contains only `ascii` characters, it should
behave similarly, with less implicit conversions).

As for python3, the previous already worked correctly:
`p.communicate()` returns a pair of `bytes` objects, which needs to be
decoded as unicode python3 `str` for clean display for the exception,
and for the output `str` is probably already expected by callers.


Tested `dmake shell` with python2 both for the normal case and when an error happens on the `find dmake.yml`. python3 should behave as before.