### PR TITLE
Avoid cleaning docker images for the 'run' command

### DIFF
--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -699,8 +699,9 @@ def make(root_dir, sub_dir, command, app, options):
     # If on local, run the commands
     if common.is_local:
         result = os.system('bash %s' % file_to_generate)
-        do_clean = True
-        if result != 0 and common.command in ['run', 'shell', 'test']:
+        # Do not clean for the 'run' command
+        do_clean = common.command != 'run'
+        if result != 0 and common.command in ['shell', 'test']:
             r = common.read_input("An error was detected. DMake will stop. The script directory is : %s.\nDo you want to stop all the running containers? [Y/n] " % common.tmp_dir)
             if r.lower() != 'y' and r != "":
                 do_clean = False


### PR DESCRIPTION
The purpose of 'run' command is to launch dockers, thus we should not trigger a cleaning at the end of dmake, otherwise they would be removed. 

A better way should be to clean the temporary directory only, without removing the docker but this is more work and not really critical.