### PR TITLE
Cleaner separation between build and run environment variables: `build.env`

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -112,10 +112,17 @@ def pull_config_dir(root_dir):
 
 ###############################################################################
 
+def get_dmake_build_type():
+    global is_release_branch
+    assert(is_release_branch is not None)
+    return "release" if is_release_branch else "testing"
+
+###############################################################################
+
 def init(_command, _root_dir, _app, _options):
     global root_dir, tmp_dir, config_dir, cache_dir, key_file
     global branch, target, is_pr, pr_id, build_id, commit_id, force_full_deploy
-    global repo_url, repo, use_pipeline, is_local, skip_tests
+    global repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
     global build_description
     global command, options, uname
     root_dir = os.path.join(_root_dir, '')
@@ -142,6 +149,9 @@ def init(_command, _root_dir, _app, _options):
 
     # Set skip test variable
     skip_tests = os.getenv('DMAKE_SKIP_TESTS', "false") == "true"
+
+    # Currently set if any dmake file describes a deploy stage matching current branch; updated after files parsing
+    is_release_branch = None
 
     use_pipeline = True
     # For PRs on Jenkins this will give the source branch name


### PR DESCRIPTION
Closes #28 

**do not merge yet** 

`.build.env` is for images build; `.env` is for runtime
environment (contains external services, secrets).

New dmake.yml root `build.env` usage: a simple dict defining
environment variables for all service builds.

Build environment should be the same for testing and deployment, for
the tests to be meaningful.
However, debug builds with coverage are useful too for development/PR.

New DMake-generated env var for all builds:
`DMAKE_BUILD_ENV={release,testing}`, set to `release` if the current
branch is for releases (currently defined as: having a deploy stage
for any service for any dmake.yml file in the repo).
Other build env vars should be local to the machine building the app,
not specializing the built image for different usages.

Remarks:
* Env values are bash-variable-substituted in an env context composed of
  dmake process env and root `env`.
* Build env are inherited at runtime: they are stored in docker image
  as `ENV`. **Do not store secrets in `build.env`**.
* `DMAKE_TESTING` is removed, and replaced by `DMAKE_BUILD_ENV`
* Also removed implicit `BUILD` env at runtime. If needed, it should
  only be used explicitly via `build.env`.