### PR TITLE
Better base image caching: docker tag derived from sources hash

### DIFF
--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -117,9 +117,8 @@ def activate_file(loaded_files, service_providers, service_dependencies, command
 
     dmake_file = loaded_files[file]
     if command == 'base':
-        root_image = dmake_file.docker.root_image
-        base_image = dmake_file.docker.get_docker_base_image_name_tag()
-        if root_image != base_image:
+        base_image = dmake_file.docker.get_docker_base_image_service()
+        if base_image is not None:
             return [('base', base_image, None)]
         else:
             return []
@@ -277,7 +276,7 @@ def load_dmake_file(loaded_files, blacklist, service_providers, service_dependen
         if common.is_string(dmake_file.docker.root_image):
             ref = dmake_file.docker.root_image
             load_dmake_file(loaded_files, blacklist, service_providers, service_dependencies, ref)
-            dmake_file.docker.__fields__['root_image'] = loaded_files[ref].docker.get_docker_base_image_name_tag()
+            dmake_file.docker.__fields__['root_image'] = loaded_files[ref].docker.root_image
         else:
             root_image = dmake_file.docker.root_image
             root_image = common.eval_str_in_env(root_image.name + ":" + root_image.tag)
@@ -285,8 +284,8 @@ def load_dmake_file(loaded_files, blacklist, service_providers, service_dependen
 
         # If a base image is declared
         root_image = dmake_file.docker.root_image
-        base_image = dmake_file.docker.get_docker_base_image_name_tag()
-        if root_image != base_image:
+        base_image = dmake_file.docker.get_docker_base_image_service()
+        if base_image is not None:
             add_service_provider(service_providers, base_image, file)
             service_dependencies[('base', base_image, None)] = [('base', root_image, None)]
 
@@ -658,6 +657,7 @@ def make(root_dir, sub_dir, command, app, options):
                 common.logger.info("- %s" % (display_command_node(node)))
 
     # Generate the list of command to run
+    common.logger.info("Generating commands...")
     all_commands = []
     append_command(all_commands, 'env', var = "REPO", value = common.repo)
     append_command(all_commands, 'env', var = "COMMIT", value = common.commit_id)

--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -636,7 +636,7 @@ def make(root_dir, sub_dir, command, app, options):
         if len(base) + len(build) + len(test) + len(deploy) != len(ordered_build_files):
             raise Exception('Something went wrong when reorganizing build steps. One of the commands is probably missing.')
 
-        ordered_build_files = [('Building Docker', base),
+        ordered_build_files = [('Building Base', base),
                                ('Building App', build),
                                ('Testing App', test)]
 

--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -443,6 +443,7 @@ def generate_command_pipeline(file, cmds):
 ###############################################################################
 
 def generate_command_bash(file, cmds):
+    file.write('test "${DMAKE_DEBUG}" = "1" && set -x\n')
     file.write('set -e\n')
     for cmd, kwargs in cmds:
         if cmd == "stage":

--- a/deepomatic/dmake/docker_registry.py
+++ b/deepomatic/dmake/docker_registry.py
@@ -1,0 +1,121 @@
+from oauthlib.oauth2 import LegacyApplicationClient
+from requests_oauthlib import OAuth2Session
+import requests
+
+import argparse
+import json
+import os
+import re
+
+from deepomatic.dmake.common import DMakeException
+
+
+REGISTRY_URL = 'https://index.docker.io'
+
+
+def get_auth_headers(registry_url, dockercfg = '~/.docker/config.json'):
+    """Extracts docker registry auth from docker config file.
+
+    Return: authorization headers
+    """
+    # https://docs.docker.com/engine/reference/commandline/login/#privileged-user-requirement
+    dockercfg = os.path.expanduser(dockercfg)
+    with open(dockercfg, 'r') as f:
+        data = json.load(f)
+    for registry, value in data['auths'].items():
+        if registry.startswith(registry_url):
+            auth = value['auth']
+            break
+    else:
+        raise DMakeException('Auth not found for registry %s in docker config file %s' % (registry_url, dockercfg))
+
+    return {'Authorization': 'Basic %s' % auth}
+
+
+def create_authenticated_requests_session(registry_url, token_url, scope, service):
+    """Performs docker registry authentication.
+
+    Return: authenticated requests.Session
+    """
+
+    # https://docs.docker.com/registry/spec/auth/oauth/
+    auth_headers = get_auth_headers(registry_url)
+    client = OAuth2Session(client=LegacyApplicationClient(client_id='dmake'))
+    client.fetch_token(token_url=token_url, headers=auth_headers, method='GET', service=service, scope=unicode(scope))
+
+    return client
+
+
+def get(registry_url, path, **kwargs):
+    """Get a docker registry url, handling authentication
+
+    Return: requests.Response
+    """
+    url = registry_url + path
+    response = requests.get(url, **kwargs)
+
+    # https://docs.docker.com/registry/spec/auth/token/
+    # Www-Authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/ubuntu:pull"
+    if response.status_code != 401 or ("Www-Authenticate" not in response.headers):
+        return response
+
+    challenge = response.headers["Www-Authenticate"]
+    regexp = '^Bearer\s+realm="(.+?)",service="(.+?)",scope="(.+?)",?'
+    match = re.match(regexp, challenge)
+
+    if not match:
+        raise DMakeException('Docker registry: Unknown Www-Authenticate challenge')
+
+    realm = match.group(1)
+    service = match.group(2)
+    scope = match.group(3)
+
+    docker_registry_client = create_authenticated_requests_session(registry_url, scope=scope, service=service, token_url=realm)
+    response = docker_registry_client.get(url, **kwargs)
+
+    return response
+
+
+def parse_docker_image(image):
+    """Parse docker image, add defaults, return components."""
+    # add defaults
+    if '/' not in image:
+        image = 'library/' + image
+    if ':' not in image:
+        image = image + ':latest'
+
+    # parse
+    tokens1 = image.split('/')
+    namespace = tokens1[0]
+
+    tokens2 = tokens1[1].split(':')
+    name = tokens2[0]
+    tag = tokens2[1]
+
+    return namespace, name, tag
+
+def get_image_digest(image):
+    """Get image digest (sha256)"""
+    namespace, name, tag = parse_docker_image(image)
+
+    # https://docs.docker.com/registry/spec/api/#pulling-an-image
+    manifest_path = '/v2/%s/%s/manifests/%s' % (namespace, name, tag)
+    headers = {'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
+    response = get(REGISTRY_URL, manifest_path, headers=headers)
+
+    # https://docs.docker.com/registry/spec/api/#content-digests
+    if response.status_code != 200 or 'Docker-Content-Digest' not in response.headers:
+        raise DMakeException('Docker registry: Error getting image digest: %s %s' % (response.status_code, response.text))
+
+    return response.headers['Docker-Content-Digest']
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=['image-digest'], default='image-digest', nargs='?', help="Command on docker registry")
+    parser.add_argument("image", default='ubuntu:16.04', nargs='?', help="Docker image")
+    args = parser.parse_args()
+
+    if args.command == 'image-digest':
+        digest = get_image_digest(args.image)
+        print("Image digest: %s: %s" % (args.image, digest))

--- a/deepomatic/dmake/utils/dmake_build_base_docker
+++ b/deepomatic/dmake/utils/dmake_build_base_docker
@@ -33,10 +33,11 @@ function docker_get_image_id() {
   docker image ls "$1" --format '{{.ID}}'
 }
 
+BASE_IMAGE="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
 ROOT_IMAGE_NAME="${ROOT_IMAGE_NAME%:*}"  # strip tag if exists: we use the digest instead
 
 # Avoid multiple rebuilds of the same base image in parallel
-LOCK="/tmp/docker-${REPO}.lock"
+LOCK="/tmp/dmake-build-docker-base-image-${BASE_IMAGE//\//_}.lock"  # replace `/` by `_` in base image name
 LOCK_TIMEOUT=600
 if command -v flock>/dev/null 2>&1; then
   LOCK=${LOCK}.flock
@@ -53,7 +54,6 @@ fi
 
 
 # Check if base image already exists
-BASE_IMAGE="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
 echo "Checking cache for docker base image (${BASE_IMAGE})"
 # first locally
 BASE_IMAGE_ID=$(docker_get_image_id $BASE_IMAGE)

--- a/deepomatic/dmake/utils/dmake_build_base_docker
+++ b/deepomatic/dmake/utils/dmake_build_base_docker
@@ -2,17 +2,18 @@
 #
 # Usage:
 # dmake_build_base_docker TMP_DIR \
-#                             ROOT_IMAGE \
-#                             DOCKER_IMAGE_NAME \
-#                             DOCKER_IMAGE_TAG
-#                             DOCKER_IMAGE_VERSION
+#                         ROOT_IMAGE_NAME \
+#                         ROOT_IMAGE_DIGEST \
+#                         DOCKER_IMAGE_NAME \
+#                         DOCKER_IMAGE_TAG \
+#                         DMAKE_DIGEST
 #
 # Result:
 # Will build and cache the base docker images with libs.
 
 test "${DMAKE_DEBUG}" = "1" && set -x
 
-if [ $# -ne 5 ]; then
+if [ $# -ne 6 ]; then
     dmake_fail "$0: Wrong arguments"
     echo "exit 1"
     exit 1
@@ -20,16 +21,21 @@ fi
 
 set -e
 
-export TMP_DIR=$1
-export ROOT_IMAGE=$2
-export DOCKER_IMAGE_NAME=$3
-export DOCKER_IMAGE_TAG=$4
-DOCKER_IMAGE_VERSION=$5
+TMP_DIR=$1; shift
+ROOT_IMAGE_NAME=$1; shift
+ROOT_IMAGE_DIGEST=$1; shift
+DOCKER_IMAGE_NAME=$1; shift
+DOCKER_IMAGE_TAG=$1; shift
+DMAKE_DIGEST=$1; shift
+
 
 function docker_get_image_id() {
-    echo `docker images | sed "1d" | sed "s/  */ /g" | cut -d ' ' -f 1-3 | sed "s/ /:/" | grep "$1 " | cut -d ' ' -f 2`
+  docker image ls "$1" --format '{{.ID}}'
 }
 
+ROOT_IMAGE_NAME="${ROOT_IMAGE_NAME%:*}"  # strip tag if exists: we use the digest instead
+
+# Avoid multiple rebuilds of the same base image in parallel
 LOCK="/tmp/docker-${REPO}.lock"
 if [ `which lockfile | wc -l | sed "s/ *//"` != "0" ]; then
     lockfile -l 600 ${LOCK}
@@ -38,117 +44,61 @@ if [ `which lockfile | wc -l | sed "s/ *//"` != "0" ]; then
     fi
 fi
 
-# Retrieve the root image ID
-echo "Retrieving ID for ${ROOT_IMAGE}"
-if [[ "$ROOT_IMAGE" != *":"* ]]; then
-    FULL_ROOT_IMAGE="$ROOT_IMAGE:latest"
-else
-    FULL_ROOT_IMAGE="$ROOT_IMAGE"
-fi
-docker pull ${FULL_ROOT_IMAGE} || :
-ID_ROOT=$(docker_get_image_id ${FULL_ROOT_IMAGE})
-if [ -z "${ID_ROOT}" ]; then
-    dmake_fail "Could not find root image: ${FULL_ROOT_IMAGE}"
-fi
 
-# Retrieve the base image
-export BASE_IMAGE="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
-BASE_IMAGE_GENERAL="${DOCKER_IMAGE_NAME}:base-${DOCKER_IMAGE_VERSION}"
-echo "Retrieving ID for ${BASE_IMAGE}"
-if [[ "${BASE_IMAGE}" =~ .+/.+ ]]; then
+# Check if base image already exists
+BASE_IMAGE="${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}"
+echo "Checking cache for docker base image (${BASE_IMAGE})"
+# first locally
+BASE_IMAGE_ID=$(docker_get_image_id $BASE_IMAGE)
+if [ -z "${BASE_IMAGE_ID}" ]; then
+  # then remotely
+  if [[ "${BASE_IMAGE}" =~ .+/.+ ]]; then
     docker pull $BASE_IMAGE || :
+  fi
+  BASE_IMAGE_ID=$(docker_get_image_id $BASE_IMAGE)
 fi
-ID_BASE=$(docker_get_image_id $BASE_IMAGE)
-#If still not found, if may be because it is a newly created branch. We pull the general base image
-if [ -z "${ID_BASE}" ] && [[ "${BASE_IMAGE_GENERAL}" =~ .+/.+ ]]; then
-    echo "${BASE_IMAGE} not found on docker-hub, try pulling ${BASE_IMAGE_GENERAL}"
-    docker pull ${BASE_IMAGE_GENERAL} || :
-    ID_BASE=$(docker_get_image_id ${BASE_IMAGE_GENERAL})
-    if [ ! -z "${ID_BASE}" ]; then
-        docker tag ${BASE_IMAGE_GENERAL} ${BASE_IMAGE}
-    fi
-fi
-
-# Display IDs
-echo "${ROOT_IMAGE}: ${ID_ROOT}"
-echo "${BASE_IMAGE}: ${ID_BASE}"
-
-# Add ID_ROOT to md5s for comparison
-echo "${ID_ROOT}" >> ${TMP_DIR}/root_image_id
 
 # Check if we need to re-build
-BUILD_BASE_DOCKER="0"
-if [ "${ID_BASE}" = "" ]; then
-    echo "Base image not available, re-building base image"
-    BUILD_BASE_DOCKER="1"
-else
-    # Output previous md5s
-    set +e
-    echo "$(docker run --rm --entrypoint="cat" -i ${ID_BASE} /base/md5s || echo '')" > ${TMP_DIR}/prev_md5s
-    echo "$(docker run --rm --entrypoint="cat" -i ${ID_BASE} /base/root_image_id || echo '')" > ${TMP_DIR}/prev_root_image_id
-    PREV_ID_ROOT=`cat ${TMP_DIR}/prev_root_image_id`
-    set -e
-fi
-
-if [ "${BUILD_BASE_DOCKER}" = "0" ]; then
-    if [ "${ID_ROOT}" != "${PREV_ID_ROOT}" ]; then
-        echo "${ROOT_IMAGE} has been updated (was previously '${PREV_ID_ROOT}'), re-building base image"
-        BUILD_BASE_DOCKER="1"
-    fi
-fi
-
-if [ "${BUILD_BASE_DOCKER}" = "0" ]; then
-    echo "Looking for changes..."
-
-    # Different file systems may output file in different orders so we sort them
-    sort -o ${TMP_DIR}/md5s ${TMP_DIR}/md5s
-    sort -o ${TMP_DIR}/prev_md5s ${TMP_DIR}/prev_md5s
-
-    FILE_CHANGED=`diff ${TMP_DIR}/md5s ${TMP_DIR}/prev_md5s | sed "1d" | head -n1 | cut -d\  -f 2`
-    if [ ! -z "${FILE_CHANGED}" ]; then
-        echo "Re-build base image because '${FILE_CHANGED}' has changed"
-        BUILD_BASE_DOCKER="1"
-    fi
-fi
-
-if [ ${BUILD_BASE_DOCKER} = "1" ]; then
-    # Remove tmp file used for previous md5
-    rm -f ${TMP_DIR}/prev_md5s
-    rm -f ${TMP_DIR}/prev_root_image_id
-
-    echo "Removing docker image ${BASE_IMAGE}"
-    docker rmi ${BASE_IMAGE} 2> /dev/null || :
-
-    echo "Building docker image ${BASE_IMAGE}"
+if [ -z "${BASE_IMAGE_ID}" ]; then
+    echo "Docker base image not found in cache, building it (${BASE_IMAGE})"
 
     if [ `uname` = "Darwin" ] && [ ! -z "${DMAKE_SSH_KEY}" ]; then
         OTHER_OPTS="-v ${DMAKE_SSH_KEY}:/key"
     fi
 
-    echo "docker run -u 0 --cidfile ${TMP_DIR}/cid.txt -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK -v ${TMP_DIR}:/base_volume ${OTHER_OPTS} ${ROOT_IMAGE} bash /base_volume/make_base.sh"
-
     if [ ! -z "$SSH_AUTH_SOCK" ]; then
         SSH_AUTH_SOCK_VOLUME="-v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
     fi
 
+    DOCKER_RUN_ARGS=( run
+                      -u 0
+                      --cidfile ${TMP_DIR}/cid.txt $SSH_AUTH_SOCK_VOLUME
+                      -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK
+                      -v ${TMP_DIR}:/base_volume
+                      ${OTHER_OPTS}
+                      ${ROOT_IMAGE_NAME}@${ROOT_IMAGE_DIGEST}
+                      /bin/bash /base_volume/make_base.sh
+                    )
+
+    echo "Executing docker ${DOCKER_RUN_ARGS[@]}"
+
     rm -f ${TMP_DIR}/cid.txt
-    docker run -u 0 --cidfile ${TMP_DIR}/cid.txt $SSH_AUTH_SOCK_VOLUME -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK -v ${TMP_DIR}:/base_volume ${OTHER_OPTS} ${ROOT_IMAGE} bash /base_volume/make_base.sh
+    docker "${DOCKER_RUN_ARGS[@]}"
+
     CID=`cat ${TMP_DIR}/cid.txt`
     if [ ! -z "${DMAKE_TMP_DIR}" ]; then
         echo ${CID} >> ${DMAKE_TMP_DIR}/containers_to_remove.txt
     fi
+
     # We commit the container into the base image
     docker commit ${CID} ${BASE_IMAGE}
 
     if [[ "${DOCKER_IMAGE_NAME}" =~ .+/.+ ]]; then
-        echo "Tagging ${BASE_IMAGE} as ${BASE_IMAGE_GENERAL}"
-        docker rmi ${BASE_IMAGE_GENERAL} || :
-        docker tag ${BASE_IMAGE} ${BASE_IMAGE_GENERAL}
+        echo "Pushing ${BASE_IMAGE}"
         docker push ${BASE_IMAGE}
-        docker push ${BASE_IMAGE_GENERAL}
     fi
 else
-    echo "No changes found."
+    echo "Docker base image found in cache, using it (${BASE_IMAGE})"
 fi
 
 rm -f ${LOCK}

--- a/deepomatic/dmake/utils/dmake_build_base_docker
+++ b/deepomatic/dmake/utils/dmake_build_base_docker
@@ -38,7 +38,12 @@ ROOT_IMAGE_NAME="${ROOT_IMAGE_NAME%:*}"  # strip tag if exists: we use the diges
 # Avoid multiple rebuilds of the same base image in parallel
 LOCK="/tmp/docker-${REPO}.lock"
 LOCK_TIMEOUT=600
-if command -v lockfile >/dev/null 2>&1; then
+if command -v flock>/dev/null 2>&1; then
+  LOCK=${LOCK}.flock
+  exec 9>${LOCK}
+  trap "rm -f ${LOCK}; exit $?" INT TERM EXIT
+  flock --exclusive --timeout ${LOCK_TIMEOUT} 9
+elif command -v lockfile >/dev/null 2>&1; then
     if [ ! -z "${DMAKE_TMP_DIR}" ]; then
         echo ${LOCK} >> ${DMAKE_TMP_DIR}/files_to_remove.txt
     fi

--- a/deepomatic/dmake/utils/dmake_build_base_docker
+++ b/deepomatic/dmake/utils/dmake_build_base_docker
@@ -37,11 +37,13 @@ ROOT_IMAGE_NAME="${ROOT_IMAGE_NAME%:*}"  # strip tag if exists: we use the diges
 
 # Avoid multiple rebuilds of the same base image in parallel
 LOCK="/tmp/docker-${REPO}.lock"
-if [ `which lockfile | wc -l | sed "s/ *//"` != "0" ]; then
-    lockfile -l 600 ${LOCK}
+LOCK_TIMEOUT=600
+if command -v lockfile >/dev/null 2>&1; then
     if [ ! -z "${DMAKE_TMP_DIR}" ]; then
         echo ${LOCK} >> ${DMAKE_TMP_DIR}/files_to_remove.txt
     fi
+    trap "rm -f ${LOCK}; exit $?" INT TERM EXIT
+    lockfile -1 -l ${LOCK_TIMEOUT} ${LOCK}
 fi
 
 
@@ -100,5 +102,3 @@ if [ -z "${BASE_IMAGE_ID}" ]; then
 else
     echo "Docker base image found in cache, using it (${BASE_IMAGE})"
 fi
-
-rm -f ${LOCK}

--- a/deepomatic/dmake/utils/dmake_deploy_kubernetes
+++ b/deepomatic/dmake/utils/dmake_deploy_kubernetes
@@ -7,6 +7,8 @@
 # Deploy resources on kubernetes, using ARGS as kubernetes manifest yaml files.
 # NAMESPACE can be emply, meaning using default namespace defined in KUBE_CONTEXT
 
+test "${DMAKE_DEBUG}" = "1" && set -x
+
 set -e
 
 if [ $# -lt 6 ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ kubernetes>=1.0.2
 urllib3>=1.20
 backports.ssl-match-hostname>=3.5.0.1
 ipaddress>=1.0.18
+requests_oauthlib==0.8.0


### PR DESCRIPTION
Closes #35 

Better base image caching: docker tag derived from sources hash

* base_image name: `.docker.base_image.name`
* base_image tag: `base-rid-$(root image digest| tr : -)-dd-$(dmake md5s file | md5)`
* rid: root image digest: docker image digest (`sha256:...`)
* dd: dmake digest (short for dmake base image build scripts digest):
  an id representing all the sources used to build the base_image on
  top of the root image digest: `$(md5sum md5s | cut -d' ' -f1)`

The base_image tag is now purely dependent on its source definition:
it can even factorize builds if 2 dmake.yml describe the same
base_image.

Also, `.docker.base_image.version` is not used anymore, keeping it for now to
avoid breaking all `dmake.yml` files.