### PR TITLE
Docker credential store

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -32,7 +32,7 @@ class NotGitRepositoryException(DMakeException):
 
 ###############################################################################
 
-def run_shell_command(commands, ignore_error=False, additional_env=None):
+def run_shell_command(commands, ignore_error=False, additional_env=None, stdin=None):
     if not isinstance(commands, list):
         commands = [commands]
     if additional_env is None:
@@ -44,12 +44,12 @@ def run_shell_command(commands, ignore_error=False, additional_env=None):
     # don't trace shell execution when run from dmake process: it would be detected as an error otherwise
     env.pop('DMAKE_DEBUG', None)
 
-    prev_stdout = None
+    prev_stdout = subprocess.PIPE if stdin else None
     for cmd in commands:
         cmd = ['bash', '-c', cmd]
         p = subprocess.Popen(cmd, stdin = prev_stdout, stdout = subprocess.PIPE, stderr = subprocess.PIPE, env = env)
         prev_stdout = p.stdout
-    stdout, stderr = p.communicate()
+    stdout, stderr = p.communicate(stdin)
     if len(stderr) > 0 and not ignore_error:
         raise ShellError(subprocess_output_to_string(stderr))
     return subprocess_output_to_string(stdout).strip()

--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -44,11 +44,11 @@ def run_shell_command(commands, ignore_error=False, additional_env=None):
     # don't trace shell execution when run from dmake process: it would be detected as an error otherwise
     env.pop('DMAKE_DEBUG', None)
 
-    prev_p = None
+    prev_stdout = None
     for cmd in commands:
         cmd = ['bash', '-c', cmd]
-        stdin = None if prev_p is None else prev_p.stdout
-        p = subprocess.Popen(cmd, stdin = stdin, stdout = subprocess.PIPE, stderr = subprocess.PIPE, env = env)
+        p = subprocess.Popen(cmd, stdin = prev_stdout, stdout = subprocess.PIPE, stderr = subprocess.PIPE, env = env)
+        prev_stdout = p.stdout
     stdout, stderr = p.communicate()
     if len(stderr) > 0 and not ignore_error:
         raise ShellError(subprocess_output_to_string(stderr))

--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -32,7 +32,7 @@ class NotGitRepositoryException(DMakeException):
 
 ###############################################################################
 
-def run_shell_command(commands, ignore_error=False, additional_env=None, stdin=None):
+def run_shell_command(commands, ignore_error=False, additional_env=None, stdin=None, raise_on_return_code=False):
     if not isinstance(commands, list):
         commands = [commands]
     if additional_env is None:
@@ -52,6 +52,8 @@ def run_shell_command(commands, ignore_error=False, additional_env=None, stdin=N
     stdout, stderr = p.communicate(stdin)
     if len(stderr) > 0 and not ignore_error:
         raise ShellError(subprocess_output_to_string(stderr))
+    if raise_on_return_code and p.returncode != 0:
+        raise ShellError("return code: %s; stdout: %sstderr: %s" % (p.returncode, subprocess_output_to_string(stdout), subprocess_output_to_string(stderr)))
     return subprocess_output_to_string(stdout).strip()
 
 def array_to_env_vars(array):

--- a/deepomatic/dmake/docker_config.py
+++ b/deepomatic/dmake/docker_config.py
@@ -1,0 +1,79 @@
+from deepomatic.dmake.common import DMakeException
+import deepomatic.dmake.common as common
+
+import json
+import os
+from requests.auth import HTTPBasicAuth
+
+def convert_to_hostname(url):
+    """ConvertToHostname converts a registry url which has http|https prepended to just an hostname."""
+    stripped = url
+    if url.startswith('http://'):
+        stripped = url[len('http://'):]
+    elif url.startswith('https://'):
+        stripped = url[len('https://'):]
+
+    parts = stripped.split('/', 1)
+    return parts[0]
+
+
+def get_docker_config_auth(registry_url, dockercfg = '~/.docker/config.json'):
+    """Parse docker config file.
+
+    Return: registry authorization config.
+    """
+    # https://docs.docker.com/engine/reference/commandline/login/#privileged-user-requirement
+    dockercfg = os.path.expanduser(dockercfg)
+    with open(dockercfg, 'r') as f:
+        cfg_data = json.load(f)
+
+    credentials_store = None
+    if 'credHelpers' in cfg_data:
+        credentials_helpers = cfg_data['credHelpers']
+        hostname = convert_to_hostname(registry_url)
+        if hostname in credentials_helpers:
+            credentials_store = credentials_helpers[hostname]
+            # TODO FIX: probably won't work with registry = hostname
+            return credentials_store, hostname, {}
+        else:
+            for registry, credentials_store in credentials_helpers.items():
+                if registry.startswith(registry_url):
+                    return credentials_store, registry, {}
+
+    if 'credsStore' in cfg_data:
+        credentials_store = cfg_data['credsStore']
+
+    for registry, registry_data in cfg_data['auths'].items():
+        if registry.startswith(registry_url):
+            return credentials_store, registry, registry_data
+    else:
+        raise DMakeException('Auth not found for registry %s in docker config file %s' % (registry_url, dockercfg))
+
+
+def docker_credentials_store(store, command, input):
+    """Calls the docker credentials store with command and input.
+
+    Return: parsed output
+    """
+    # https://docs.docker.com/engine/reference/commandline/login/#credentials-store
+    output = common.run_shell_command('docker-credential-%s %s' % (store, command), stdin=input, raise_on_return_code=True)
+
+    return json.loads(output)
+
+
+def get_auth_kwargs(registry_url):
+    """Extracts docker registry auth from docker config file.
+
+    Return: authorization headers or auth
+    """
+    credentials_store, registry, data = get_docker_config_auth(registry_url)
+    if credentials_store is None:
+        # get from config file data
+        # TODO parse value and return a (user,password) tuple instead of a requests kwargs
+        headers = {'Authorization': 'Basic %s' % data['auth']}
+        return {'headers': headers}
+    else:
+        # get from credentials store
+        data = docker_credentials_store(credentials_store, 'get', registry)
+        auth = HTTPBasicAuth(data['Username'], data['Secret'])
+        return {'auth': auth}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ kubernetes>=1.0.2
 urllib3>=1.20
 backports.ssl-match-hostname>=3.5.0.1
 ipaddress>=1.0.18
-requests_oauthlib==0.8.0
+oauthlib>=2.0.6
+requests-oauthlib==0.8.0


### PR DESCRIPTION
Closes #53

Parse more auth variants from docker config file: support credsStore and credHelpers

Now support these config:
* `base`:
```
{
        "auths": {
                "https://index.docker.io/v1/": {
                        "auth": "foobar="
                }
        }
}
```
* `credsStore`:
```
{
	"auths": {
		"https://index.docker.io/v1/": {}
	},
	"credsStore": "osxkeychain"
}
```
* `credHelpers`:
```
{
        "auths": {
                "https://index.docker.io/v1/": {}
        },
        "credHelpers": {
                "https://index.docker.io/v1/": "secretservice"
        }
}
```