### PR TITLE
Add a .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.dmake
+**/dmake.yml


### PR DESCRIPTION
When building the docker images it now ignores:
* .git dir
* dmake files

It's safer (no secrets from dmake files in build context), and faster.