### PR TITLE
Fix duplicated docker options.

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -940,7 +940,6 @@ class DMakeFile(DMakeFileSerializer):
         if service.config is None or service.config.docker_image.start_script is None:
             return
 
-
         unique_service_name = service_name
         customized_env = {}
         if service_customization:
@@ -958,8 +957,7 @@ class DMakeFile(DMakeFileSerializer):
             append_command(commands, 'sh', shell = "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
         # </DEPRECATED>
 
-        daemon_opts = "%s %s" % (service.config.full_docker_opts(True), opts)
-        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, daemon_opts, image_name))
+        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, opts, image_name))
 
         cmd = service.config.readiness_probe.get_cmd()
         if cmd:


### PR DESCRIPTION
`dmake run` previously generated duplicated docker options such as
ports.

Regression introduced by 079cd449e340943f4ce8e1769db5c360ac00558b.

Fixed by removing duplicate calls to `full_docker_opts`:
- once in `opts` from `_launch_options_`: kept
- once in `generate_run` directly: removed