### PR TITLE
More readable stage and steps logs for bash execution.

### DIFF
--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -447,7 +447,7 @@ def generate_command_bash(file, cmds):
     for cmd, kwargs in cmds:
         if cmd == "stage":
             file.write("\n")
-            file.write("echo %s\n" % kwargs['name'])
+            file.write("echo -e '\n## %s ##'\n" % kwargs['name'])
         elif cmd == "echo":
             message = kwargs['message'].replace("'", "\\'")
             file.write("echo '%s'\n" % message)
@@ -670,7 +670,7 @@ def make(root_dir, sub_dir, command, app, options):
             append_command(all_commands, 'stage', name = stage, concurrency = 1 if stage == "Deploying" else None)
         for node, order in commands:
             command, service, service_customization = node
-            append_command(all_commands, 'echo', message = 'Running %s' % (display_command_node(node)))
+            append_command(all_commands, 'echo', message = '- Running %s' % (display_command_node(node)))
             if command == 'build':
                 dmake_file = loaded_files[service]
             else:


### PR DESCRIPTION
New output:
```
Generating commands...
Output has been written to /tmp/dmake_tmp_xxx/DMakefile

## Building Base ##
- Running base @ deepomatic/xxx::base
Checking cache for docker base image (deepomatic/xxx)
Docker base image found in cache, using it (deepomatic/xxx)

## Testing App ##
- Running run_link @ links/vesta/rabbitmq
3.6-management: Pulling from library/rabbitmq
Digest: sha256:xxx
Status: Image is up to date for rabbitmq:3.6-management
dmake_wait_for_it: waiting 30 seconds for 172.17.0.2:5672
dmake_wait_for_it: 172.17.0.2:5672 is available after 6 seconds
- Running run_link @ links/vesta/db
9.6: Pulling from library/postgres
Digest: sha256:xxx
Status: Image is up to date for postgres:9.6
dmake_wait_for_it: waiting 30 seconds for 172.17.0.3:5432
dmake_wait_for_it: 172.17.0.3:5432 is available after 0 seconds
- Running run_link @ links/vesta/redis
4.0: Pulling from library/redis
Digest: sha256:xxx
Status: Image is up to date for redis:4.0
dmake_wait_for_it: waiting 30 seconds for 172.17.0.4:6379
dmake_wait_for_it: 172.17.0.4:6379 is available after 0 seconds

## Deploying ##
- Running shell @ vesta/web
I have no name!@8174512cadb1:/vesta/web$
```