### PR TITLE
Fix dmake stop

### DIFF
--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -502,7 +502,7 @@ def make(root_dir, sub_dir, command, app, options):
         app = None
 
     if common.command == "stop":
-        common.run_shell_command("docker rm -f `docker ps -q -f name=%s.%s.%s`" % (app, common.branch, common.build_id))
+        common.run_shell_command("docker rm -f `docker ps -q -f name=%s.%s.%s`" % (common.repo, common.branch, common.build_id))
         return
 
     # Format args


### PR DESCRIPTION
`dmake stop` should stop containers started by `dmake start`.
It previously failed because it searched wrong container names.

The run_daemon is called with empty name, and auto generated names have
`repo.branch.build` as prefix: using that to stop containers.