### PR TITLE
Fix `copy_directories`: it's now a path relative to current dmake.yml irectory, as imposed by the "dir" type.

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -552,9 +552,7 @@ class ServiceDockerSerializer(YAML2PipelineSerializer):
 
         generate_copy_command(commands, tmp_dir, path_dir)
         for d in self.copy_directories:
-            if d == path_dir:
-                continue
-            generate_copy_command(commands, tmp_dir, d)
+            generate_copy_command(commands, tmp_dir, os.path.join(path_dir, '..', d))
 
         mount_point = docker_base.mount_point
         dockerfile = os.path.join(tmp_dir, 'Dockerfile')


### PR DESCRIPTION
Previously it was a path relative to repo root directory, but the
newer "dir" type broke that by checking its existence relative to
current dmake.yml directory.

No project seem to have broken (it is not used), so keeping new "dir"
type semantic to be more coherent.