### PR TITLE
Change CMD of base image: /bin/bash

### DIFF
--- a/deepomatic/dmake/utils/dmake_build_base_docker
+++ b/deepomatic/dmake/utils/dmake_build_base_docker
@@ -98,7 +98,7 @@ if [ -z "${BASE_IMAGE_ID}" ]; then
     fi
 
     # We commit the container into the base image
-    docker commit ${CID} ${BASE_IMAGE}
+    docker commit --change='CMD ["/bin/bash"]' ${CID} ${BASE_IMAGE}
 
     if [[ "${DOCKER_IMAGE_NAME}" =~ .+/.+ ]]; then
         echo "Pushing ${BASE_IMAGE}"


### PR DESCRIPTION
By default `docker commit` takes the latest cmd as CMD:
/base_volume/make_base.sh. This doesn't exist after the build, so it
makes no sense to keep that. It just disturbs manual users of the base
image (for debug).