### PR TITLE
Add support for GPU in shell, test and run

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -943,6 +943,10 @@ class DMakeFile(DMakeFileSerializer):
         if service.config is None or service.config.docker_image.start_script is None:
             return
 
+        docker_run_prefix = ''
+        if service.config.need_gpu:
+            docker_run_prefix = 'DOCKER_CMD=nvidia-docker '
+
         unique_service_name = service_name
         customized_env = {}
         if service_customization:
@@ -957,10 +961,10 @@ class DMakeFile(DMakeFileSerializer):
         # <DEPRECATED>
         if service.config.pre_deploy_script:
             cmd = service.config.pre_deploy_script
-            append_command(commands, 'sh', shell = "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
+            append_command(commands, 'sh', shell = docker_run_prefix + "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
         # </DEPRECATED>
 
-        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, opts, image_name))
+        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = docker_run_prefix + 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, opts, image_name))
 
         cmd = service.config.readiness_probe.get_cmd()
         if cmd:
@@ -975,7 +979,7 @@ class DMakeFile(DMakeFileSerializer):
         cmd = " && ".join(cmd)
         if cmd:
             cmd = 'bash -c %s' % common.wrap_cmd(cmd)
-            append_command(commands, 'sh', shell = "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
+            append_command(commands, 'sh', shell = docker_run_prefix + "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
         # </DEPRECATED>
 
     def generate_build(self, commands):
@@ -1026,7 +1030,12 @@ class DMakeFile(DMakeFileSerializer):
 
         docker_opts += " -i %s" % self.docker.get_docker_base_image_name_tag()
 
-        return "dmake_run_docker_command %s " % docker_opts
+        docker_cmd = "dmake_run_docker_command %s " % docker_opts
+
+        if service.config.need_gpu:
+            docker_cmd = 'DOCKER_CMD=nvidia-docker ' + docker_cmd
+
+        return docker_cmd
 
     def generate_shell(self, commands, service_name, docker_links):
         service = self._get_service_(service_name)

--- a/deepomatic/dmake/utils/dmake_run_docker
+++ b/deepomatic/dmake/utils/dmake_run_docker
@@ -48,4 +48,4 @@ if [ ! -z "${TMP_DIR}" ]; then
     echo ${NAME} >> ${TMP_DIR}/containers_to_remove.txt
 fi
 
-docker run --name ${NAME} "$@"
+${DOCKER_CMD:-docker} run --name ${NAME} "$@"


### PR DESCRIPTION
`need_gpu` was previously only supported on SSH deployments; now it is
also supported for local operations: `shell`, `test` and `run`.

It requires `nvidia-docker` (as in the SSH deployment).

It doesn't apply to build step (because it doesn't make sense), nor for now to run_links (`docker_links`), external dependencies for test, as we don't have `need_gpu` option for them yet.