### PR TITLE
 SSH deployment: Install nvidia-docker v2 instead of v1.

### DIFF
--- a/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
+++ b/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
@@ -43,10 +43,15 @@ if [ "${DOCKER_CMD}" = "nvidia-docker" ]; then
     modprobe nvidia
     modprobe nvidia_uvm
     if [ ! `which nvidia-docker` ]; then
+        # install nvidia-docker v2
+        curl -L https://nvidia.github.io/nvidia-docker/gpgkey | apt-key add -
+        tee /etc/apt/sources.list.d/nvidia-docker.list <<< \
+"deb https://nvidia.github.io/libnvidia-container/ubuntu16.04/amd64 /
+deb https://nvidia.github.io/nvidia-container-runtime/ubuntu16.04/amd64 /
+deb https://nvidia.github.io/nvidia-docker/ubuntu16.04/amd64 /"
         apt-get update
-        apt-get install nvidia-modprobe
-        wget -P /tmp https://github.com/NVIDIA/nvidia-docker/releases/download/v1.0.1/nvidia-docker_1.0.1-1_amd64.deb
-        sudo dpkg -i /tmp/nvidia-docker*.deb && rm /tmp/nvidia-docker*.deb
+        apt-get install nvidia-docker2
+        systemctl reload docker
     fi
 fi
 
@@ -104,4 +109,3 @@ if [ ! -z "${POST_DEPLOY_HOOKS}" ]; then
     echo "Running post-deploy script ${POST_DEPLOY_HOOKS}"
     $RUN_COMMAND_HOOKS ${POST_DEPLOY_HOOKS}
 fi
-

--- a/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
+++ b/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
@@ -37,7 +37,7 @@ fi
 if [ "${DOCKER_CMD}" = "nvidia-docker" ]; then
     if [ ! `which nvidia-smi` ]; then
         apt-get update
-        apt-get install nvidia-375
+        apt-get install nvidia-384
     fi
     # Make sure modules are loaded
     modprobe nvidia


### PR DESCRIPTION
It is retro-compatible thanks to a `nvidia-docker` shell wrapper.

We should later drop the usage of `nvidia-docker` itself at is is not
needed anymore.

`nvidia-docker` v2 installation doc: https://github.com/NVIDIA/nvidia-docker/tree/2.0#installation

Only potential issue: installing this overwrites `/etc/docker/daemon.json`. Luckily we don't change that in production servers.