### PR TITLE
Multi base image

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -7,7 +7,7 @@ from ruamel.yaml import YAML
 
 # Set logger
 logger = logging.getLogger("deepomatic.dmake")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.INFO) #TODO configurable
 logger.addHandler(logging.StreamHandler())
 
 ###############################################################################

--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -147,7 +147,7 @@ def get_dmake_build_type():
 ###############################################################################
 
 def init(_command, _root_dir, _app, _options):
-    global root_dir, tmp_dir, config_dir, cache_dir, key_file
+    global root_dir, tmp_dir, config_dir, cache_dir, relative_cache_dir, key_file
     global branch, target, is_pr, pr_id, build_id, commit_id, force_full_deploy
     global repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
     global build_description
@@ -160,7 +160,8 @@ def init(_command, _root_dir, _app, _options):
     config_dir = os.getenv('DMAKE_CONFIG_DIR', None)
     if config_dir is None:
         raise DMakeException("DMake seems to be badly configured: environment variable DMAKE_CONFIG_DIR is missing. Try to run %s again." % os.path.join(os.getenv('DMAKE_PATH', ""), 'install.sh'))
-    cache_dir = os.path.join(root_dir, '.dmake')
+    relative_cache_dir = '.dmake'
+    cache_dir = os.path.join(root_dir, relative_cache_dir)
     try:
         os.mkdir(cache_dir)
     except OSError:

--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -102,8 +102,9 @@ def load_dmake_files_list():
 
 def add_service_provider(service_providers, service, file, needs = None):
     if service in service_providers:
-        if service_providers[service] != file:
-            raise DMakeException('Service %s re-defined in %s. First defined in %s' % (service, file, service_providers[service]))
+        existing_service_provider, _ = service_providers[service]
+        if existing_service_provider != file:
+            raise DMakeException('Service %s re-defined in %s. First defined in %s' % (service, file, existing_service_provider))
     else:
         service_providers[service] = (file, needs)
 

--- a/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
+++ b/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
@@ -69,12 +69,6 @@ RUN_COMMAND="${DOCKER_CMD} run ${DOCKER_OPTS} -v /var/log:/var/log"
 DOCKER_SHARE_OPTS="-v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):/usr/bin/docker -v /usr/lib/x86_64-linux-gnu/libltdl.so.7:/usr/lib/x86_64-linux-gnu/libltdl.so.7"
 RUN_COMMAND_HOOKS="$RUN_COMMAND --rm $DOCKER_SHARE_OPTS -t -i ${IMAGE_NAME}"
 
-# Run pre hooks (deprecated)
-if [ ! -z "${PRE_DEPLOY_HOOKS}" ]; then
-    echo "Running pre-deploy script ${PRE_DEPLOY_HOOKS}"
-    $RUN_COMMAND_HOOKS ${PRE_DEPLOY_HOOKS}
-fi
-
 # Switch images
 echo "Deploying new app version"
 docker rm -f ${APP_NAME}-tmp || :
@@ -84,12 +78,6 @@ $RUN_COMMAND --restart unless-stopped --name ${APP_NAME}-tmp -d -i ${IMAGE_NAME}
 if [ ! -z '${READYNESS_PROBE}' ]; then # '' are importants here as there might be unescaped " in READYNESS_PROBE
     echo "Running readyness probe"
     docker exec ${APP_NAME}-tmp ${READYNESS_PROBE}
-fi
-
-# Run mid hooks (deprecated)
-if [ ! -z "${MID_DEPLOY_HOOKS}" ]; then
-    echo "Running mid-deploy script ${MID_DEPLOY_HOOKS}"
-    $RUN_COMMAND_HOOKS ${MID_DEPLOY_HOOKS}
 fi
 
 docker stop ${APP_NAME} &> /dev/null || :
@@ -103,9 +91,3 @@ if [ ! -z "$IDS" ]; then
     docker rmi $IDS
 fi
 set -e
-
-# Run post hooks (deprecated)
-if [ ! -z "${POST_DEPLOY_HOOKS}" ]; then
-    echo "Running post-deploy script ${POST_DEPLOY_HOOKS}"
-    $RUN_COMMAND_HOOKS ${POST_DEPLOY_HOOKS}
-fi

--- a/deepomatic/dmake/utils/dmake_run_docker_test
+++ b/deepomatic/dmake/utils/dmake_run_docker_test
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Usage:
+# dmake_run_docker_test SERVICE_NAME NAME ARGS...
+#
+# Result:
+# Run a docker command in foreground and save its ID in the test ids list (and the list of containers to remove)
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -lt 2 ]; then
+    dmake_fail "$0: Missing arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    exit 1
+fi
+
+set -e
+
+SERVICE_NAME=$1
+NAME=$2
+shift 2
+
+TMP_DIR=$(dmake_make_tmp_dir)
+
+dmake_run_docker "" "${NAME}" --cidfile ${TMP_DIR}/cid.txt "$@"
+CONTAINER_ID=$(cat ${TMP_DIR}/cid.txt)
+
+if [ ! -z "${SERVICE_NAME}" ]; then
+    echo "${CONTAINER_ID} ${SERVICE_NAME}" >> ${DMAKE_TMP_DIR}/test_ids.txt
+fi
+
+echo ${CONTAINER_ID} >> ${DMAKE_TMP_DIR}/containers_to_remove.txt

--- a/deepomatic/dmake/utils/dmake_test_get_results
+++ b/deepomatic/dmake/utils/dmake_test_get_results
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Usage:
+# dmake_test_get_results SERVICE_NAME SRC_PATH DEST_PATH
+#
+# Result:
+# docker cp test output for SERVICE_NAME
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -ne 3 ]; then
+    dmake_fail "$0: Wrong arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    exit 1
+fi
+
+set -e
+
+SERVICE_NAME=$1; shift
+SRC_PATH=$1; shift
+DEST_PATH=$1; shift
+
+echo "Tests results for '${SERVICE_NAME}': '${DEST_PATH}'"
+
+LINE=`cat ${DMAKE_TMP_DIR}/test_ids.txt | grep " ${SERVICE_NAME}\$" || :`
+if [ -z "${LINE}" ]; then
+  dmake_fail "Unexpected error: unknown service ${SERVICE_NAME}"
+  exit 1
+fi
+CONTAINER_ID=`echo ${LINE} | cut -d\  -f 1`
+
+mkdir -p $(dirname ${DEST_PATH})
+docker cp ${CONTAINER_ID}:${SRC_PATH} ${DEST_PATH}

--- a/tutorial/web/app/tests.py
+++ b/tutorial/web/app/tests.py
@@ -4,6 +4,11 @@ import json
 import math
 
 class FactorialTest(TestCase):
+    def test_slash(self):
+        c = Client()
+        response = c.get('/')
+        self.assertTrue(len(response.content) > 0)
+
     def test_get(self):
         c = Client()
         response = c.get('/api/factorial', {'n': 4})

--- a/tutorial/web/app/tests.py
+++ b/tutorial/web/app/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.test import Client
 import json
+import math
 
 class FactorialTest(TestCase):
     def test_get(self):
@@ -9,3 +10,11 @@ class FactorialTest(TestCase):
         data = json.loads(response.content)
         self.assertEqual('result' in data, True)
         self.assertEqual(data['result'], 24)
+
+    def test_multiple_get(self):
+        c = Client()
+        for n in range(12):
+            response = c.get('/api/factorial', {'n': n})
+            data = json.loads(response.content)
+            self.assertEqual('result' in data, True)
+            self.assertEqual(data['result'], math.factorial(n))

--- a/tutorial/web/app/views.py
+++ b/tutorial/web/app/views.py
@@ -41,7 +41,7 @@ def kombu_connect():
                                      exchange = exchange,
                                      passive = False,
                                      durable     = False,
-                                     exclusive   = True,
+                                     exclusive   = False,
                                      auto_delete = True)
         response_queue.declare()
 
@@ -74,4 +74,3 @@ def call_worker(request):
     data = struct.unpack("Q", data.body)[0]
 
     return JsonResponse({"result": data})
-

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -25,7 +25,8 @@ services:
     needed_links:
       - rabbitmq
     needed_services:
-      - worker
+      - worker:ubuntu-1604
+      - worker:ubuntu-1804
     config:
       docker_image:
         entrypoint: deploy/entrypoint.sh
@@ -35,4 +36,4 @@ services:
           host_port: 8000
     tests:
       commands:
-        - ./manage.py test
+        - ./manage.py test --verbosity=2

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -36,4 +36,17 @@ services:
           host_port: 8000
     tests:
       commands:
-        - ./manage.py test --verbosity=2
+        - touch 'tag' # test shared environment for multiple commands test
+        - test -f "tag"  # test command escaping
+        - >-
+          ./manage.py test
+          --verbosity=2 --noinput
+          --with-coverage --cover-package=. --cover-branches --cover-erase --cover-html --cover-html-dir cover --cover-xml --cover-xml-file coverage.xml
+          --with-xunit --xunit-file nosetests.xml
+          --nologcapture
+          --with-id
+      junit_report: nosetests.xml
+      html_report:
+        directory: cover
+        title: Web HTML coverage report
+      cobertura_report: coverage.xml

--- a/tutorial/web/requirements.txt
+++ b/tutorial/web/requirements.txt
@@ -2,3 +2,6 @@ amqp==2.1.1
 Django==1.10.3
 kombu==4.0.0
 vine==1.1.3
+nose==1.3.7
+django-nose==1.4.5
+coverage==4.4.2

--- a/tutorial/web/web/settings.py
+++ b/tutorial/web/web/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_nose',
     'app'
 ]
 
@@ -119,3 +120,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/tutorial/worker/deploy/dependencies.sh
+++ b/tutorial/worker/deploy/dependencies.sh
@@ -11,7 +11,7 @@ apt-get --no-install-recommends -y install make cmake g++ wget tar
 apt-get --no-install-recommends -y install librabbitmq-dev
 
 # Boost
-apt-get --no-install-recommends -y install libboost1.58-dev libboost-chrono-dev libboost-system-dev
+apt-get --no-install-recommends -y install libboost-dev libboost-chrono-dev libboost-system-dev
 
 # Google Logging
 apt-get --no-install-recommends -y install libgoogle-glog-dev

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -2,13 +2,16 @@ dmake_version: 0.1
 app_name: dmake-tutorial
 
 docker:
-  root_image:
-    name: ubuntu
-    tag: 16.04
   base_image:
-    name: dmake-tutorial-worker-base
-    install_scripts:
-      - deploy/dependencies.sh
+    - &base
+      name: dmake-tutorial-worker-base
+      variant: ubuntu-1604
+      root_image: ubuntu:16.04
+      install_scripts:
+        - deploy/dependencies.sh
+    - <<: *base
+      variant: ubuntu-1804
+      root_image: ubuntu:18.04
 
 env:
   default:
@@ -36,6 +39,10 @@ services:
       - rabbitmq
     config:
       docker_image:
+        name: dmake-tutorial-worker
+        base_image_variant:
+          - ubuntu-1604
+          - ubuntu-1804
         entrypoint: deploy/entrypoint.sh
         start_script: deploy/start.sh
     tests:

--- a/tutorial/worker/src/amqp_client.cpp
+++ b/tutorial/worker/src/amqp_client.cpp
@@ -34,7 +34,11 @@ AMQPWrapper::AMQPWrapper()
 
 void AMQPWrapper::declareQueue(const std::string &queue)
 {
-    _channel->DeclareQueue(queue);
+    bool passive = false;
+    bool durable = false;
+    bool exclusive = false;
+    bool auto_delete = true;
+    _channel->DeclareQueue(queue, passive, durable, exclusive, auto_delete);
     _channel->BindQueue(queue, "amq.direct", queue);
 }
 

--- a/tutorial/worker/src/amqp_client.hpp
+++ b/tutorial/worker/src/amqp_client.hpp
@@ -39,9 +39,13 @@ bool AMQPWrapper::recv(const std::string &queue, T &n)
 template<class T>
 bool AMQPWrapper::recv(const std::string &queue, T &n, std::string &reply_queue)
 {
+    const std::string consumer_tag = "";
+    bool no_local = true;
+    bool no_ack = true;
+    bool exclusive = false;
     auto it = _consumer_tags.find(queue);
     if (it == _consumer_tags.end()) {
-        it = _consumer_tags.emplace(queue, _channel->BasicConsume(queue)).first;
+        it = _consumer_tags.emplace(queue, _channel->BasicConsume(queue, consumer_tag, no_local, no_ack, exclusive)).first;
     }
 
     amqp_bytes_t buffer;


### PR DESCRIPTION
Closes #75 

Support multiple base image variants per `dmake.yml`, and support multiple base image variants per service (a.k.a service variants).

Work:
- [x] multiple base_images per `dmake.yml` file: `docker.base_image` can be an array, added `root_image` to it, and `variant` to distinguish between different base_image variants (both are mandatory when used as array).
- [x] select different base_image in services: `services[].config.docker_image.base_image_variant`
- [x] allow multiple base_image_variant per service
- [x] review yaml design and naming
- [x] cleanup git branch
- [x] add test
- [x] fix parallel build and tests (#94, #110)
- [x] everything still works