### PR TITLE
Execute tests using service docker image, not base docker image.

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -147,7 +147,7 @@ def get_dmake_build_type():
 ###############################################################################
 
 def init(_command, _root_dir, _app, _options):
-    global root_dir, tmp_dir, config_dir, cache_dir, key_file
+    global root_dir, tmp_dir, config_dir, cache_dir, relative_cache_dir, key_file
     global branch, target, is_pr, pr_id, build_id, commit_id, force_full_deploy
     global repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
     global build_description
@@ -160,7 +160,8 @@ def init(_command, _root_dir, _app, _options):
     config_dir = os.getenv('DMAKE_CONFIG_DIR', None)
     if config_dir is None:
         raise DMakeException("DMake seems to be badly configured: environment variable DMAKE_CONFIG_DIR is missing. Try to run %s again." % os.path.join(os.getenv('DMAKE_PATH', ""), 'install.sh'))
-    cache_dir = os.path.join(root_dir, '.dmake')
+    relative_cache_dir = '.dmake'
+    cache_dir = os.path.join(root_dir, relative_cache_dir)
     try:
         os.mkdir(cache_dir)
     except OSError:

--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -172,11 +172,9 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
             children = []
             if with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
-            children += activate_service(loaded_files, service_providers, service_dependencies, 'build', service)
+            children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
-        elif command == 'build':
-            children = activate_base(base_variant)
         elif command == 'build_docker':
             children = activate_base(base_variant)
         elif command == 'run':
@@ -187,8 +185,8 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
         elif command == 'run_link':
             children = []
         elif command == 'deploy':
-            children  = activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
-            children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
+            children  = activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
+            children += activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
         else:
             raise Exception("Unknown command '%s'" % command)
 
@@ -350,6 +348,17 @@ def order_dependencies(dependencies, sorted_leaves):
 
 ###############################################################################
 
+def make_path_unique_per_variant(path, service_name):
+    """If multi variant: prefix filename with `<variant>-`"""
+    service_name_parts = service_name.split(':')
+    if len(service_name_parts) == 2:
+        variant = service_name_parts[1]
+        head, tail = os.path.split(path)
+        path = os.path.join(head, '%s-%s' % (variant, tail))
+    return path
+
+###############################################################################
+
 def generate_command_pipeline(file, cmds):
     indent_level = 0
 
@@ -362,6 +371,9 @@ def generate_command_pipeline(file, cmds):
         write_line("currentBuild.description = '%s'" % common.build_description.replace("'", "\\'"))
     write_line('try {')
     indent_level += 1
+
+    cobertura_tests_results_dir = os.path.join(common.relative_cache_dir, 'cobertura_tests_results')
+    emit_cobertura = False
 
     for cmd, kwargs in cmds:
         if cmd == "stage":
@@ -428,11 +440,25 @@ def generate_command_pipeline(file, cmds):
                 write_line("""  sh('echo "%s"')""" % error_msg.replace("'", "\\'"))
                 write_line('}')
         elif cmd == "junit":
-            write_line("junit '%s'" % kwargs['report'])
+            container_report = os.path.join(kwargs['mount_point'], kwargs['report'])
+            host_report = os.path.join(common.relative_cache_dir, 'tests_results', str(uuid.uuid4()), kwargs['service_name'].replace(':', '-'), kwargs['report'])
+            write_line('''sh('dmake_test_get_results "%s" "%s" "%s"')''' % (kwargs['service_name'], container_report, host_report))
+            write_line("junit '%s'" % host_report)
+            write_line('''sh('rm -rf "%s"')''' % host_report)
         elif cmd == "cobertura":
-            write_line("step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '%s', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])" % (kwargs['report']))
+            # coberturaPublisher plugin only supports one step, so we delay generating it, and make it get all reports
+            container_report = os.path.join(kwargs['mount_point'], kwargs['report'])
+            host_report = os.path.join(cobertura_tests_results_dir, str(uuid.uuid4()), kwargs['service_name'].replace(':', '-'), kwargs['report'])
+            if not host_report.endswith('.xml'):
+                raise DMakeException("`cobertura_report` must end with '.xml' in service '%s'" % kwargs['service_name'])
+            write_line('''sh('dmake_test_get_results "%s" "%s" "%s"')''' % (kwargs['service_name'], container_report, host_report))
+            emit_cobertura = True
         elif cmd == "publishHTML":
-            write_line("publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: true, keepAll: false, reportDir: '%s', reportFiles: '%s', reportName: '%s'])" % (kwargs['directory'], kwargs['index'], kwargs['title'].replace("'", "\'")))
+            container_html_directory = os.path.join(kwargs['mount_point'], kwargs['directory'])
+            host_html_directory = os.path.join(common.cache_dir, 'tests_results', str(uuid.uuid4()), kwargs['service_name'].replace(':', '-'), kwargs['directory'])
+            write_line('''sh('dmake_test_get_results "%s" "%s" "%s"')''' % (kwargs['service_name'], container_html_directory, host_html_directory))
+            write_line("publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: true, keepAll: false, reportDir: '%s', reportFiles: '%s', reportName: '%s'])" % (host_html_directory, kwargs['index'], kwargs['title'].replace("'", "\'")))
+            write_line('''sh('rm -rf "%s"')''' % host_html_directory)
         elif cmd == "build":
             parameters = []
             for var, value in kwargs['parameters'].items():
@@ -446,6 +472,10 @@ def generate_command_pipeline(file, cmds):
                     "true" if kwargs['wait'] else "false"))
         else:
             raise DMakeException("Unknown command %s" % cmd)
+
+    if emit_cobertura:
+        write_line("step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '%s/**/*.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])" % (cobertura_tests_results_dir))
+        write_line('''sh('rm -rf "%s"')''' % cobertura_tests_results_dir)
 
     indent_level -= 1
     write_line('}')
@@ -489,12 +519,14 @@ def generate_command_bash(file, cmds):
         elif cmd == "git_tag":
             file.write('git tag --force %s\n' % kwargs['tag'])
             file.write('git push --force origin refs/tags/%s || echo %s\n' % (kwargs['tag'], tag_push_error_msg))
-        elif cmd == "junit":
-            pass  # Should be configured with GUI
-        elif cmd == "cobertura":
-            pass  # Should be configured with GUI
+        elif cmd == "junit" or cmd == "cobertura":
+            container_report = os.path.join(kwargs['mount_point'], kwargs['report'])
+            host_report = make_path_unique_per_variant(kwargs['report'], kwargs['service_name'])
+            file.write('dmake_test_get_results "%s" "%s" "%s"\n' % (kwargs['service_name'], container_report, host_report))
         elif cmd == "publishHTML":
-            pass  # Should be configured with GUI
+            container_html_directory = os.path.join(kwargs['mount_point'], kwargs['directory'])
+            host_html_directory = make_path_unique_per_variant(kwargs['directory'], kwargs['service_name'])
+            file.write('dmake_test_get_results "%s" "%s" "%s"\n' % (kwargs['service_name'], container_html_directory, host_html_directory))
         elif cmd == "build":
             pass  # Should be configured with GUI
         else:

--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -459,17 +459,6 @@ def generate_command_pipeline(file, cmds):
             write_line('''sh('dmake_test_get_results "%s" "%s" "%s"')''' % (kwargs['service_name'], container_html_directory, host_html_directory))
             write_line("publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: true, keepAll: false, reportDir: '%s', reportFiles: '%s', reportName: '%s'])" % (host_html_directory, kwargs['index'], kwargs['title'].replace("'", "\'")))
             write_line('''sh('rm -rf "%s"')''' % host_html_directory)
-        elif cmd == "build":
-            parameters = []
-            for var, value in kwargs['parameters'].items():
-                value = common.eval_str_in_env(value)
-                parameters.append("string(name: '%s', value: '%s')" % (var.replace("'", "\\'"), value.replace("'", "\\'")))
-            parameters = ','.join(parameters)
-            write_line("build job: '%s', parameters: [%s], propagate: %s, wait: %s" % (
-                    kwargs['job'].replace("'", "\\'"),
-                    parameters,
-                    "true" if kwargs['propagate'] else "false",
-                    "true" if kwargs['wait'] else "false"))
         else:
             raise DMakeException("Unknown command %s" % cmd)
 
@@ -527,8 +516,6 @@ def generate_command_bash(file, cmds):
             container_html_directory = os.path.join(kwargs['mount_point'], kwargs['directory'])
             host_html_directory = make_path_unique_per_variant(kwargs['directory'], kwargs['service_name'])
             file.write('dmake_test_get_results "%s" "%s" "%s"\n' % (kwargs['service_name'], container_html_directory, host_html_directory))
-        elif cmd == "build":
-            pass  # Should be configured with GUI
         else:
             raise DMakeException("Unknown command %s" % cmd)
 
@@ -695,7 +682,7 @@ def make(root_dir, sub_dir, command, app, options):
     else:
         n = len(ordered_build_files)
         base   = list(filter(lambda a_b__c: a_b__c[0][0] in ['base'], ordered_build_files))
-        build  = list(filter(lambda a_b__c: a_b__c[0][0] in ['build', 'build_docker'], ordered_build_files))
+        build  = list(filter(lambda a_b__c: a_b__c[0][0] in ['build_docker'], ordered_build_files))
         test   = list(filter(lambda a_b__c: a_b__c[0][0] in ['test', 'run_link', 'run'], ordered_build_files))
         deploy = list(filter(lambda a_b__c: a_b__c[0][0] in ['shell', 'deploy'], ordered_build_files))
         if len(base) + len(build) + len(test) + len(deploy) != len(ordered_build_files):
@@ -754,8 +741,6 @@ def make(root_dir, sub_dir, command, app, options):
                     dmake_file.generate_run(step_commands, service, links, service_customization)
                 elif command == "run_link":
                     dmake_file.generate_run_link(step_commands, service, links)
-                elif command == "build":
-                    dmake_file.generate_build(step_commands, service)
                 elif command == "build_docker":
                     dmake_file.generate_build_docker(step_commands, service)
                 elif command == "deploy":

--- a/deepomatic/dmake/core.py
+++ b/deepomatic/dmake/core.py
@@ -1,4 +1,5 @@
 import os, sys
+import uuid
 
 import deepomatic.dmake.common as common
 from   deepomatic.dmake.common import DMakeException
@@ -406,7 +407,7 @@ def generate_command_pipeline(file, cmds):
                 write_line(','.join(commands_list))
                 write_line(')')
         elif cmd == "read_sh":
-            file_output = os.path.join(common.root_dir, ".dmake", "output_%d" % kwargs['id'])
+            file_output = os.path.join(common.cache_dir, "output_%s" % uuid.uuid4())
             write_line("sh('%s > %s')" % (kwargs['shell'], file_output))
             write_line("env.%s = readFile '%s'" % (kwargs['var'], file_output));
             if kwargs['fail_if_empty']:

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -1,7 +1,7 @@
 import os
 import copy
 import json
-import random
+import uuid
 import importlib
 from deepomatic.dmake.serializer import ValidationError, FieldSerializer, YAML2PipelineSerializer
 import deepomatic.dmake.common as common
@@ -29,7 +29,6 @@ def append_command(commands, cmd, prepend = False, **args):
         check_cmd(args, ['shell'])
     elif cmd == "read_sh":
         check_cmd(args, ['var', 'shell'], optional = ['fail_if_empty'])
-        args['id'] = len(commands)
         if 'fail_if_empty' not in args:
             args['fail_if_empty'] = False
     elif cmd == "env":
@@ -64,7 +63,7 @@ def generate_copy_command(commands, tmp_dir, src):
 
 def generate_env_file(tmp_dir, env):
     while True:
-        file = os.path.join(tmp_dir, 'env.txt.%d' % random.randint(0, 999999))
+        file = os.path.join(tmp_dir, 'env.txt.%s' % uuid.uuid4())
         if not os.path.isfile(file):
             break
     with open(file, 'w') as f:

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -965,8 +965,8 @@ class DMakeFileSerializer(YAML2PipelineSerializer):
     docker             = FieldSerializer([FieldSerializer("file", help_text = "to another dmake file (which will be added to dependencies) that declares a docker field, in which case it replaces this file's docker field."), DockerSerializer()], help_text = "The environment in which to build and deploy.")
     docker_links       = FieldSerializer("array", child = DockerLinkSerializer(), default = [], help_text = "List of link to create, they are shared across the whole application, so potentially across multiple dmake files.")
     build              = BuildSerializer(help_text = "Commands to run for building the application.")
-    pre_test_commands  = FieldSerializer("array", default = [], child = "string", help_text = "Command list to run before running tests.")
-    post_test_commands = FieldSerializer("array", default = [], child = "string", help_text = "Command list to run after running tests.")
+    pre_test_commands  = FieldSerializer("array", default = [], child = "string", help_text = "Deprecated, not used anymore, will be removed later. Use `tests.commands` instead.")
+    post_test_commands = FieldSerializer("array", default = [], child = "string", help_text = "Deprecated, not used anymore, will be removed later. Use `tests.commands` instead.")
     services           = FieldSerializer("array", child = ServicesSerializer(), default = [], help_text = "Service list.")
 
     def _validate_(self, file, needed_migrations, data, field_name=''):
@@ -1221,14 +1221,8 @@ class DMakeFile(DMakeFileSerializer):
         service = self._get_service_(service_name)
         docker_cmd = self._generate_test_docker_cmd_(commands, service, docker_links)
 
-        # Run pre-test commands
-        for cmd in self.pre_test_commands:
-            append_command(commands, 'sh', shell = docker_cmd + cmd)
         # Run test commands
         service.tests.generate_test(commands, self.app_name, docker_cmd, docker_links)
-        # Run post-test commands
-        for cmd in self.post_test_commands:
-            append_command(commands, 'sh', shell = docker_cmd + cmd)
 
     def generate_run_link(self, commands, service, docker_links):
         service = service.split('/')

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -836,7 +836,7 @@ class TestSerializer(YAML2PipelineSerializer):
     cobertura_report   = FieldSerializer("string", optional = True, example = "**/coverage.xml", help_text = "Publish a Cobertura report. **WARNING** only one is allowed per repository.")
     html_report        = HTMLReportSerializer(optional = True, help_text = "Publish an HTML report.")
 
-    def generate_test(self, commands, service_name, docker_cmd, docker_links, mount_point):
+    def generate_test(self, commands, path, service_name, docker_cmd, docker_links, mount_point):
         if not self.has_value() or len(self.commands) == 0:
             return
 
@@ -844,15 +844,15 @@ class TestSerializer(YAML2PipelineSerializer):
         append_command(commands, 'sh', shell = docker_cmd + tests_cmd)
 
         if self.junit_report is not None:
-            append_command(commands, 'junit', report = self.junit_report, service_name = service_name, mount_point = mount_point)
+            append_command(commands, 'junit', report = os.path.join(path, self.junit_report), service_name = service_name, mount_point = mount_point)
 
         if self.cobertura_report is not None:
-            append_command(commands, 'cobertura', report = self.cobertura_report, service_name = service_name, mount_point = mount_point)
+            append_command(commands, 'cobertura', report = os.path.join(path, self.cobertura_report), service_name = service_name, mount_point = mount_point)
 
         html = self.html_report._value_()
         if html is not None:
             append_command(commands, 'publishHTML', service_name = service_name, mount_point = mount_point,
-                           directory = html['directory'],
+                           directory = os.path.join(path, html['directory']),
                            index     = html['index'],
                            title     = html['title'],)
 
@@ -1228,7 +1228,7 @@ class DMakeFile(DMakeFileSerializer):
         docker_cmd = self._generate_test_docker_cmd_(commands, service, service_name, docker_links)
 
         # Run test commands
-        service.tests.generate_test(commands, service_name, docker_cmd, docker_links, self.docker.mount_point)
+        service.tests.generate_test(commands, self.__path__, service_name, docker_cmd, docker_links, self.docker.mount_point)
 
     def generate_run_link(self, commands, service, docker_links):
         service = service.split('/')

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -37,11 +37,11 @@ def append_command(commands, cmd, prepend = False, **args):
     elif cmd == "git_tag":
         check_cmd(args, ['tag'])
     elif cmd == "junit":
-        check_cmd(args, ['report'])
+        check_cmd(args, ['report', 'service_name', 'mount_point'])
     elif cmd == "cobertura":
-        check_cmd(args, ['report'])
+        check_cmd(args, ['report', 'service_name', 'mount_point'])
     elif cmd == "publishHTML":
-        check_cmd(args, ['directory', 'index', 'title'])
+        check_cmd(args, ['directory', 'index', 'title', 'service_name', 'mount_point'])
     elif cmd == "build":
         check_cmd(args, ['job', 'parameters', 'propagate', 'wait'])
     else:
@@ -80,7 +80,9 @@ class EnvBranchSerializer(YAML2PipelineSerializer):
     source    = FieldSerializer('string', optional=True, help_text='Source a bash file which defines the environment variables before evaluating the strings of environment variables passed in the *variables* field. It might contain environment variables itself.')
     variables = FieldSerializer('dict', child="string", default={}, help_text="Defines environment variables used for the services declared in this file. You might use pre-defined environment variables (or variables sourced from the file defined in the *source* field).", example={'ENV_TYPE': 'dev'})
 
-    def get_replaced_variables(self, additional_variables={}, docker_links=None, needed_links=None):
+    def get_replaced_variables(self, additional_variables=None, docker_links=None, needed_links=None):
+        if additional_variables is None:
+            additional_variables = {}
         replaced_variables = {}
         if self.has_value() and (len(self.variables) or len(additional_variables)):
             if self.source is not None:
@@ -837,25 +839,25 @@ class TestSerializer(YAML2PipelineSerializer):
     cobertura_report   = FieldSerializer("string", optional = True, example = "**/coverage.xml", help_text = "Publish a Cobertura report. **WARNING** only one is allowed per repository.")
     html_report        = HTMLReportSerializer(optional = True, help_text = "Publish an HTML report.")
 
-    def generate_test(self, commands, app_name, docker_cmd, docker_links):
-        if not self.has_value():
+    def generate_test(self, commands, service_name, docker_cmd, docker_links, mount_point):
+        if not self.has_value() or len(self.commands) == 0:
             return
 
-        for cmd in self.commands:
-            append_command(commands, 'sh', shell = docker_cmd + cmd)
+        tests_cmd = '/bin/bash -c %s' % common.wrap_cmd(' && '.join(self.commands))
+        append_command(commands, 'sh', shell = docker_cmd + tests_cmd)
 
         if self.junit_report is not None:
-            append_command(commands, 'junit', report = self.junit_report)
+            append_command(commands, 'junit', report = self.junit_report, service_name = service_name, mount_point = mount_point)
 
         if self.cobertura_report is not None:
-            append_command(commands, 'cobertura', report = self.cobertura_report)
+            append_command(commands, 'cobertura', report = self.cobertura_report, service_name = service_name, mount_point = mount_point)
 
         html = self.html_report._value_()
         if html is not None:
-            append_command(commands, 'publishHTML',
-                directory = html['directory'],
-                index     = html['index'],
-                title     = html['title'])
+            append_command(commands, 'publishHTML', service_name = service_name, mount_point = mount_point,
+                           directory = html['directory'],
+                           index     = html['index'],
+                           title     = html['title'],)
 
 class NeededServiceSerializer(YAML2PipelineSerializer):
     service_name    = FieldSerializer("string", help_text = "The name of the needed application part.", example = "worker-nn", no_slash_no_space = True)
@@ -1198,11 +1200,11 @@ class DMakeFile(DMakeFileSerializer):
 
         return docker_opts
 
-    def _generate_test_docker_cmd_(self, commands, service, docker_links):
+    def _generate_shell_docker_cmd_(self, commands, service, docker_links):
         docker_opts  = self._launch_options_(commands, service, docker_links, self.build.env, run_base_image=True, mount_root_dir=True)
 
         if service.tests.has_value():
-            opts=[]
+            opts = []
             for data_volume in service.tests.data_volumes:
                 opts.append(data_volume.get_mount_opt())
             docker_opts += " " + (" ".join(opts))
@@ -1212,17 +1214,36 @@ class DMakeFile(DMakeFileSerializer):
 
         return "dmake_run_docker_command %s " % docker_opts
 
+    def _generate_test_docker_cmd_(self, commands, service, service_name, docker_links):
+        docker_opts  = self._launch_options_(commands, service, docker_links, env=None, run_base_image=False, mount_root_dir=False)
+
+        if service.tests.has_value():
+            opts = []
+            for data_volume in service.tests.data_volumes:
+                opts.append(data_volume.get_mount_opt())
+            docker_opts += " " + (" ".join(opts))
+
+        env = self.env.get_replaced_variables(docker_links=docker_links, needed_links=service.needed_links)
+        image_name = service.config.docker_image.get_image_name(env = env)
+        docker_opts += " -i %s" % image_name
+
+        return 'dmake_run_docker_test %s "" %s ' % (service_name, docker_opts)
+
     def generate_shell(self, commands, service_name, docker_links):
         service = self._get_service_(service_name)
-        docker_cmd = self._generate_test_docker_cmd_(commands, service, docker_links)
+        docker_cmd = self._generate_shell_docker_cmd_(commands, service, docker_links)
         append_command(commands, 'sh', shell = docker_cmd + self.docker.command)
 
     def generate_test(self, commands, service_name, docker_links):
         service = self._get_service_(service_name)
-        docker_cmd = self._generate_test_docker_cmd_(commands, service, docker_links)
+        if not service.tests.has_value():
+            return
+        if not service.config.docker_image.has_value():
+            raise DMakeException("You need to specify a 'config.docker_image' when testing.")
+        docker_cmd = self._generate_test_docker_cmd_(commands, service, service_name, docker_links)
 
         # Run test commands
-        service.tests.generate_test(commands, self.app_name, docker_cmd, docker_links)
+        service.tests.generate_test(commands, service_name, docker_cmd, docker_links, self.docker.mount_point)
 
     def generate_run_link(self, commands, service, docker_links):
         service = service.split('/')

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -824,6 +824,14 @@ class TestSerializer(YAML2PipelineSerializer):
     cobertura_report   = FieldSerializer("string", optional = True, example = "**/coverage.xml", help_text = "Publish a Cobertura report. **WARNING** only one is allowed per repository.")
     html_report        = HTMLReportSerializer(optional = True, help_text = "Publish an HTML report.")
 
+    def get_mounts_opt(self, service_name):
+        if not self.has_value():
+            return ''
+        opts = []
+        for data_volume in self.data_volumes:
+            opts.append(data_volume.get_mount_opt(service_name))
+        return ' ' + ' '.join(opts)
+
     def generate_test(self, commands, path, service_name, docker_cmd, docker_links, mount_point):
         if not self.has_value() or len(self.commands) == 0:
             return
@@ -1106,6 +1114,16 @@ class DMakeFile(DMakeFileSerializer):
         base_image = self.docker.get_base_image_from_service_name(base_image_service_name)
         base_image._serialize_(commands, self.__path__)
 
+    def _generate_run_docker_opts_(self, commands, service, docker_links, env=None):
+        if env is None:
+            env = {}
+        docker_opts = self._launch_options_(commands, service, docker_links, env=env, run_base_image=False, mount_root_dir=False)
+
+        env = self.env.get_replaced_variables(docker_links=docker_links, needed_links=service.needed_links)
+        image_name = service.config.docker_image.get_image_name(env=env)
+
+        return docker_opts, image_name
+
     def generate_run(self, commands, service_name, docker_links, service_customization):
         service = self._get_service_(service_name)
         if not service.config.has_value() or not service.config.docker_image.has_value() or service.config.docker_image.start_script is None:
@@ -1118,12 +1136,13 @@ class DMakeFile(DMakeFileSerializer):
             # daemon name: <app_name>/<service_name><optional_unique_suffix>; service_name already contains "<app_name>/"
             unique_service_name += service_customization.get_service_name_unique_suffix()
 
-        opts = self._launch_options_(commands, service, docker_links, customized_env, run_base_image=False, mount_root_dir=False)
-        env = self.env.get_replaced_variables(docker_links=docker_links, needed_links=service.needed_links)
-        image_name = service.config.docker_image.get_image_name(env = env)
+        docker_opts, image_name = self._generate_run_docker_opts_(commands, service, docker_links, customized_env)
+        docker_cmd = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, docker_opts, image_name)
 
-        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, opts, image_name))
+        # Run daemon
+        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = docker_cmd)
 
+        # Wait for daemon to be ready
         cmd = service.config.readiness_probe.get_cmd()
         if cmd:
             append_command(commands, 'sh', shell = 'dmake_exec_docker "$DAEMON_ID" %s' % cmd)
@@ -1155,38 +1174,17 @@ class DMakeFile(DMakeFileSerializer):
 
         return docker_opts
 
-    def _generate_shell_docker_cmd_(self, commands, service, service_name, docker_links):
-        docker_opts  = self._launch_options_(commands, service, docker_links, self.build.env, run_base_image=True, mount_root_dir=True)
+    def generate_shell(self, commands, service_name, docker_links):
+        service = self._get_service_(service_name)
 
-        if service.tests.has_value():
-            opts = []
-            for data_volume in service.tests.data_volumes:
-                opts.append(data_volume.get_mount_opt(service_name))
-            docker_opts += " " + (" ".join(opts))
+        docker_opts = self._launch_options_(commands, service, docker_links, self.build.env, run_base_image=True, mount_root_dir=True)
+        docker_opts += service.tests.get_mounts_opt(service_name)
 
         docker_base_image = self.docker.get_docker_base_image(service.get_base_image_variant())
         docker_opts += " -i %s" % docker_base_image
 
-        return "dmake_run_docker_command %s " % docker_opts
+        docker_cmd = "dmake_run_docker_command %s " % docker_opts
 
-    def _generate_test_docker_cmd_(self, commands, service, service_name, docker_links):
-        docker_opts  = self._launch_options_(commands, service, docker_links, env=None, run_base_image=False, mount_root_dir=False)
-
-        if service.tests.has_value():
-            opts = []
-            for data_volume in service.tests.data_volumes:
-                opts.append(data_volume.get_mount_opt(service_name))
-            docker_opts += " " + (" ".join(opts))
-
-        env = self.env.get_replaced_variables(docker_links=docker_links, needed_links=service.needed_links)
-        image_name = service.config.docker_image.get_image_name(env = env)
-        docker_opts += " -i %s" % image_name
-
-        return 'dmake_run_docker_test %s "" %s ' % (service_name, docker_opts)
-
-    def generate_shell(self, commands, service_name, docker_links):
-        service = self._get_service_(service_name)
-        docker_cmd = self._generate_shell_docker_cmd_(commands, service, service_name, docker_links)
         append_command(commands, 'sh', shell = docker_cmd + self.docker.command)
 
     def generate_test(self, commands, service_name, docker_links):
@@ -1195,7 +1193,10 @@ class DMakeFile(DMakeFileSerializer):
             return
         if not service.config.docker_image.has_value():
             raise DMakeException("You need to specify a 'config.docker_image' when testing.")
-        docker_cmd = self._generate_test_docker_cmd_(commands, service, service_name, docker_links)
+
+        docker_opts, image_name = self._generate_run_docker_opts_(commands, service, docker_links)
+        docker_opts += service.tests.get_mounts_opt(service_name)
+        docker_cmd = 'dmake_run_docker_test %s "" %s -i %s ' % (service_name, docker_opts, image_name)
 
         # Run test commands
         service.tests.generate_test(commands, self.__path__, service_name, docker_cmd, docker_links, self.docker.mount_point)

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -42,8 +42,6 @@ def append_command(commands, cmd, prepend = False, **args):
         check_cmd(args, ['report', 'service_name', 'mount_point'])
     elif cmd == "publishHTML":
         check_cmd(args, ['directory', 'index', 'title', 'service_name', 'mount_point'])
-    elif cmd == "build":
-        check_cmd(args, ['job', 'parameters', 'propagate', 'wait'])
     else:
         raise DMakeException("Unknown command %s" % cmd)
     cmd = (cmd, args)
@@ -1160,18 +1158,6 @@ class DMakeFile(DMakeFileSerializer):
             cmd = 'bash -c %s' % common.wrap_cmd(cmd)
             append_command(commands, 'sh', shell = "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
         # </DEPRECATED>
-
-    def generate_build(self, commands, service_name):
-        if not self.build.has_value():
-            return
-        service = self._get_service_(service_name)
-        docker_base_image = self.docker.get_docker_base_image(service.get_base_image_variant())
-        docker_cmd = self._generate_docker_cmd_(self.docker, env=self.build.env)
-        docker_cmd += ' -e DMAKE_BUILD_TYPE=%s ' % common.get_dmake_build_type()
-        docker_cmd += " -i %s " % docker_base_image
-
-        for cmds in self.build.commands:
-            append_command(commands, 'sh', shell = ["dmake_run_docker_command " + docker_cmd + ' %s' % cmd for cmd in cmds])
 
     def generate_build_docker(self, commands, service_name):
         service = self._get_service_(service_name)

--- a/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
+++ b/deepomatic/dmake/templates/deploy/deploy_ssh/start_app.sh
@@ -69,12 +69,6 @@ RUN_COMMAND="${DOCKER_CMD} run ${DOCKER_OPTS} -v /var/log:/var/log"
 DOCKER_SHARE_OPTS="-v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):/usr/bin/docker -v /usr/lib/x86_64-linux-gnu/libltdl.so.7:/usr/lib/x86_64-linux-gnu/libltdl.so.7"
 RUN_COMMAND_HOOKS="$RUN_COMMAND --rm $DOCKER_SHARE_OPTS -t -i ${IMAGE_NAME}"
 
-# Run pre hooks (deprecated)
-if [ ! -z "${PRE_DEPLOY_HOOKS}" ]; then
-    echo "Running pre-deploy script ${PRE_DEPLOY_HOOKS}"
-    $RUN_COMMAND_HOOKS ${PRE_DEPLOY_HOOKS}
-fi
-
 # Switch images
 echo "Deploying new app version"
 docker rm -f ${APP_NAME}-tmp || :
@@ -84,12 +78,6 @@ $RUN_COMMAND --restart unless-stopped --name ${APP_NAME}-tmp -d -i ${IMAGE_NAME}
 if [ ! -z '${READYNESS_PROBE}' ]; then # '' are importants here as there might be unescaped " in READYNESS_PROBE
     echo "Running readyness probe"
     docker exec ${APP_NAME}-tmp ${READYNESS_PROBE}
-fi
-
-# Run mid hooks (deprecated)
-if [ ! -z "${MID_DEPLOY_HOOKS}" ]; then
-    echo "Running mid-deploy script ${MID_DEPLOY_HOOKS}"
-    $RUN_COMMAND_HOOKS ${MID_DEPLOY_HOOKS}
 fi
 
 docker stop ${APP_NAME} &> /dev/null || :
@@ -103,9 +91,3 @@ if [ ! -z "$IDS" ]; then
     docker rmi $IDS
 fi
 set -e
-
-# Run post hooks (deprecated)
-if [ ! -z "${POST_DEPLOY_HOOKS}" ]; then
-    echo "Running post-deploy script ${POST_DEPLOY_HOOKS}"
-    $RUN_COMMAND_HOOKS ${POST_DEPLOY_HOOKS}
-fi

--- a/deepomatic/dmake/utils/dmake_run_docker_test
+++ b/deepomatic/dmake/utils/dmake_run_docker_test
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Usage:
+# dmake_run_docker_test SERVICE_NAME NAME ARGS...
+#
+# Result:
+# Run a docker command in foreground and save its ID in the test ids list (and the list of containers to remove)
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -lt 2 ]; then
+    dmake_fail "$0: Missing arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    exit 1
+fi
+
+set -e
+
+SERVICE_NAME=$1
+NAME=$2
+shift 2
+
+TMP_DIR=$(dmake_make_tmp_dir)
+
+dmake_run_docker "" "${NAME}" --cidfile ${TMP_DIR}/cid.txt "$@"
+CONTAINER_ID=$(cat ${TMP_DIR}/cid.txt)
+
+if [ ! -z "${SERVICE_NAME}" ]; then
+    echo "${CONTAINER_ID} ${SERVICE_NAME}" >> ${DMAKE_TMP_DIR}/test_ids.txt
+fi
+
+echo ${CONTAINER_ID} >> ${DMAKE_TMP_DIR}/containers_to_remove.txt

--- a/deepomatic/dmake/utils/dmake_test_get_results
+++ b/deepomatic/dmake/utils/dmake_test_get_results
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Usage:
+# dmake_test_get_results SERVICE_NAME SRC_PATH DEST_PATH
+#
+# Result:
+# docker cp test output for SERVICE_NAME
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -ne 3 ]; then
+    dmake_fail "$0: Wrong arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    exit 1
+fi
+
+set -e
+
+SERVICE_NAME=$1; shift
+SRC_PATH=$1; shift
+DEST_PATH=$1; shift
+
+echo "Tests results for '${SERVICE_NAME}': '${DEST_PATH}'"
+
+LINE=`cat ${DMAKE_TMP_DIR}/test_ids.txt | grep " ${SERVICE_NAME}\$" || :`
+if [ -z "${LINE}" ]; then
+  dmake_fail "Unexpected error: unknown service ${SERVICE_NAME}"
+  exit 1
+fi
+CONTAINER_ID=`echo ${LINE} | cut -d\  -f 1`
+
+mkdir -p $(dirname ${DEST_PATH})
+docker cp ${CONTAINER_ID}:${SRC_PATH} ${DEST_PATH}

--- a/tutorial/web/app/tests.py
+++ b/tutorial/web/app/tests.py
@@ -4,6 +4,11 @@ import json
 import math
 
 class FactorialTest(TestCase):
+    def test_slash(self):
+        c = Client()
+        response = c.get('/')
+        self.assertTrue(len(response.content) > 0)
+
     def test_get(self):
         c = Client()
         response = c.get('/api/factorial', {'n': 4})

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -36,6 +36,8 @@ services:
           host_port: 8000
     tests:
       commands:
+        - touch 'tag' # test shared environment for multiple commands test
+        - test -f "tag"  # test command escaping
         - >-
           ./manage.py test
           --verbosity=2 --noinput

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -45,8 +45,8 @@ services:
           --with-xunit --xunit-file nosetests.xml
           --nologcapture
           --with-id
-      junit_report: tutorial/web/nosetests.xml
+      junit_report: nosetests.xml
       html_report:
-        directory: tutorial/web/cover
+        directory: cover
         title: Web HTML coverage report
-      cobertura_report: 'tutorial/web/coverage.xml'
+      cobertura_report: coverage.xml

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -36,4 +36,15 @@ services:
           host_port: 8000
     tests:
       commands:
-        - ./manage.py test --verbosity=2
+        - >-
+          ./manage.py test
+          --verbosity=2 --noinput
+          --with-coverage --cover-package=. --cover-branches --cover-erase --cover-html --cover-html-dir cover --cover-xml --cover-xml-file coverage.xml
+          --with-xunit --xunit-file nosetests.xml
+          --nologcapture
+          --with-id
+      junit_report: tutorial/web/nosetests.xml
+      html_report:
+        directory: tutorial/web/cover
+        title: Web HTML coverage report
+      cobertura_report: 'tutorial/web/coverage.xml'

--- a/tutorial/web/requirements.txt
+++ b/tutorial/web/requirements.txt
@@ -2,3 +2,6 @@ amqp==2.1.1
 Django==1.10.3
 kombu==4.0.0
 vine==1.1.3
+nose==1.3.7
+django-nose==1.4.5
+coverage==4.4.2

--- a/tutorial/web/web/settings.py
+++ b/tutorial/web/web/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_nose',
     'app'
 ]
 
@@ -119,3 +120,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'


### PR DESCRIPTION
Closes #34

Pros:
- test production/official service docker image instead of a parallel
  build (without install step)
- avoid duplicate build
- avoid writing build files in host workspace
- allows parallel build

Cons:
- need to ship tests programs (and its dependencies) in official image

TODO:
- [x] use service image to execute tests
- [x] execute tests all at once in one container so they share the environment like before
- [x] refactor code
- [x] access test results (using `docker cp`)
- [x] migrate tests users to not use `*` anymore (not supported anymore, to be able to do explicit `docker cp`)
- [x] fix vulcain `api-tmp` which has a `tests` but no `config`: it's not supported anymore, since `config.docker_image` describes how to build the service docker image 
- [x] everything still works