### PR TITLE
`kubectl` fails on error only when it returns a non-zero return code

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -74,7 +74,7 @@ def run_shell_command(commands, ignore_error=False, additional_env=None, stdin=N
         p = subprocess.Popen(cmd, stdin = prev_stdout, stdout = subprocess.PIPE, stderr = subprocess.PIPE, env = env)
         prev_stdout = p.stdout
     stdout, stderr = p.communicate(stdin)
-    if len(stderr) > 0 and not ignore_error:
+    if len(stderr) > 0 and not ignore_error and not raise_on_return_code:
         raise ShellError(subprocess_output_to_string(stderr))
     if raise_on_return_code and p.returncode != 0:
         raise ShellError("return code: %s; stdout: %sstderr: %s" % (p.returncode, subprocess_output_to_string(stdout), subprocess_output_to_string(stderr)))

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -468,7 +468,7 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
             from_file_args = ["--from-file=%s=%s" % (file_source.key, file_source.path) for file_source in cm.from_files]
             args = ['create', 'configmap', '--dry-run=true', '--output=yaml', cm.name] + from_file_args
             cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
-            cm_data = common.run_shell_command(cmd)
+            cm_data = common.run_shell_command(cmd, raise_on_return_code=True)
             cm_datas.append(cm_data)
         with open(os.path.join(tmp_dir, user_configmaps_filename), 'w') as f:
             f.write('\n\n---\n\n'.join(cm_datas))
@@ -490,7 +490,7 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
         args = ['apply', '--dry-run=true', '--validate=true', '--filename=%s' % user_manifest_path]
         cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
         try:
-            common.run_shell_command(cmd)
+            common.run_shell_command(cmd, raise_on_return_code=True)
         except common.ShellError as e:
             raise DMakeException("%s: Invalid Kubernetes manifest file %s (rendered template: %s): %s" % (app_name, self.manifest, user_manifest_path, e))
 


### PR DESCRIPTION
Used and changed semantic for `common.run_shell_command`
`raise_on_return_code`: now it raises an error *only* on non-zero
return code.
Previously it also returned an error if stderr is non-empty, which
makes no sense, but is kept for backward compatibility.

stderr warning example:
```
W1205 16:54:23.957959   14961 factory_object_mapping.go:423] Failed to download OpenAPI (the server could not find the requested resource), falling back to swagger
```