### PR TITLE
Revert "Add support for GPU in shell, test and run (#72)"

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -976,10 +976,6 @@ class DMakeFile(DMakeFileSerializer):
         if not service.config.has_value() or not service.config.docker_image.has_value() or service.config.docker_image.start_script is None:
             return
 
-        docker_run_prefix = ''
-        if service.config.need_gpu:
-            docker_run_prefix = 'DOCKER_CMD=nvidia-docker '
-
         unique_service_name = service_name
         customized_env = {}
         if service_customization:
@@ -994,10 +990,10 @@ class DMakeFile(DMakeFileSerializer):
         # <DEPRECATED>
         if service.config.pre_deploy_script:
             cmd = service.config.pre_deploy_script
-            append_command(commands, 'sh', shell = docker_run_prefix + "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
+            append_command(commands, 'sh', shell = "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
         # </DEPRECATED>
 
-        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = docker_run_prefix + 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, opts, image_name))
+        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, opts, image_name))
 
         cmd = service.config.readiness_probe.get_cmd()
         if cmd:
@@ -1012,7 +1008,7 @@ class DMakeFile(DMakeFileSerializer):
         cmd = " && ".join(cmd)
         if cmd:
             cmd = 'bash -c %s' % common.wrap_cmd(cmd)
-            append_command(commands, 'sh', shell = docker_run_prefix + "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
+            append_command(commands, 'sh', shell = "dmake_run_docker_command %s -i %s %s" % (opts, image_name, cmd))
         # </DEPRECATED>
 
     def generate_build(self, commands):
@@ -1063,12 +1059,7 @@ class DMakeFile(DMakeFileSerializer):
 
         docker_opts += " -i %s" % self.docker.get_docker_base_image_name_tag()
 
-        docker_cmd = "dmake_run_docker_command %s " % docker_opts
-
-        if service.config.has_value() and service.config.need_gpu:
-            docker_cmd = 'DOCKER_CMD=nvidia-docker ' + docker_cmd
-
-        return docker_cmd
+        return "dmake_run_docker_command %s " % docker_opts
 
     def generate_shell(self, commands, service_name, docker_links):
         service = self._get_service_(service_name)

--- a/deepomatic/dmake/utils/dmake_run_docker
+++ b/deepomatic/dmake/utils/dmake_run_docker
@@ -48,4 +48,4 @@ if [ ! -z "${TMP_DIR}" ]; then
     echo ${NAME} >> ${TMP_DIR}/containers_to_remove.txt
 fi
 
-${DOCKER_CMD:-docker} run --name ${NAME} "$@"
+docker run --name ${NAME} "$@"


### PR DESCRIPTION
This reverts commit c02e06ce06ab75b3434063ff9979b12273213710.

For local GPU use, install nvidia-docker v2 and configure it as
default docker runtime engine. This will make all docker images
inheriting nvidia ones working; which is currently the case for all
usages.

Later we should re-add explicit usage with the `--runtime=nvidia`
option alongside `NVIDIA_*` environment variables.