### PR TITLE
Fix copy on MacOS

### DIFF
--- a/deepomatic/dmake/utils/dmake_copy
+++ b/deepomatic/dmake/utils/dmake_copy
@@ -26,6 +26,6 @@ set -e
 SOURCE_PATH=$1
 TARGET_PATH=$2
 mkdir -p $(dirname ${TARGET_PATH})
-cp -rL ${SOURCE_PATH} ${TARGET_PATH}
+cp -RL ${SOURCE_PATH} ${TARGET_PATH}
 
 dmake_md5 ${TARGET_PATH}


### PR DESCRIPTION
`cp -r` is a bad practice on MacOS, please use `cp -R`