### PR TITLE
Support root images with non-shell entrypoint

### DIFF
--- a/deepomatic/dmake/utils/dmake_build_base_docker
+++ b/deepomatic/dmake/utils/dmake_build_base_docker
@@ -83,8 +83,9 @@ if [ -z "${BASE_IMAGE_ID}" ]; then
                       -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK
                       -v ${TMP_DIR}:/base_volume
                       ${OTHER_OPTS}
+                      --entrypoint /bin/bash
                       ${ROOT_IMAGE_NAME}@${ROOT_IMAGE_DIGEST}
-                      /bin/bash /base_volume/make_base.sh
+                      -c "bash /base_volume/make_base.sh"
                     )
 
     echo "Executing docker ${DOCKER_RUN_ARGS[@]}"


### PR DESCRIPTION
Closes #120 

Some root images have an entrypoint not compatible with a shell, so we
override it with /bin/bash.

Example with nvidia/digits with `ENTRYPOINT ["python", "-m", "digits"]`:
```
$ docker run --rm nvidia/digits:latest echo ok
usage: __main__.py [-h] [-p PORT] [-d] [--version]
__main__.py: error: unrecognized arguments: echo ok

$ docker run --rm --entrypoint /bin/bash nvidia/digits:latest -c "echo ok"
ok
```