### PR TITLE
Fix `docker_links` volume non-persistence during tests.

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -306,7 +306,7 @@ class DockerLinkSerializer(YAML2PipelineSerializer):
 
     def get_options(self, path, env):
         options = common.eval_str_in_env(self.testing_options, env)
-        if common.command in ["shell", "test"]:
+        if common.command == "shell":
             for vol in self.volumes:
                 vol = common.eval_str_in_env(vol, env)
                 vol = vol.split(':')


### PR DESCRIPTION
Fix #124 .

For the tests we don't want persistence of data.

If volumes are needed for sharing between services, then use raw `testing_options`.