### PR TITLE
kubernetes deployment: Stop using slash in kubectl annotate

### DIFF
--- a/deepomatic/dmake/utils/dmake_deploy_kubernetes
+++ b/deepomatic/dmake/utils/dmake_deploy_kubernetes
@@ -50,11 +50,11 @@ echo_title Annotate ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
 # TODO currently not atomic: multiple apply can work in parallel, and this command may annotate the wrong version
 prefix="dmake.deepomatic.com"
 ANNOTATE_ARGS=( "${BASE_ARGS[@]}" annotate deployment/${SERVICE} --overwrite=true --record=false
-                ${prefix}/deploy-timestamp="${deploy_timestamp}"
-                ${prefix}/service=${SERVICE}
-                ${prefix}/git-repository=${REPO}
-                ${prefix}/git-branch="${BRANCH}"
-                ${prefix}/git-revision=${COMMIT}
+                ${prefix}-deploy-timestamp="${deploy_timestamp}"
+                ${prefix}-service=${SERVICE}
+                ${prefix}-git-repository=${REPO}
+                ${prefix}-git-branch="${BRANCH}"
+                ${prefix}-git-revision=${COMMIT}
               )
 echo kubectl "${ANNOTATE_ARGS[@]}"
 kubectl "${ANNOTATE_ARGS[@]}"


### PR DESCRIPTION
Fix #127 

It's broken with kubectl 1.7 and kubernetes master 1.8.