### PR TITLE
Fix dmake execution from a submodule directory.

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -107,8 +107,19 @@ def join_without_slash(*args):
 ###############################################################################
 
 def find_repo_root(path=os.getcwd()):
-    root_dir = run_shell_command('git -C %s rev-parse --show-toplevel' %(path))
-    sub_dir = os.path.relpath(path, root_dir)
+    root_dir = path
+    sub_dir = ''
+    while True:
+        if os.path.isdir(os.path.join(root_dir, '.git')):
+            break
+        else:
+            if root_dir == '/':
+                raise NotGitRepositoryException()
+            sub_dir = os.path.join(os.path.basename(root_dir), sub_dir)
+            root_dir = os.path.normpath(os.path.join(root_dir, '..'))
+            if root_dir.startswith('..'):
+                return None, None
+    sub_dir = os.path.normpath(sub_dir)
     if sub_dir == '.':
         sub_dir = '' # IMPORTANT: Need to get rid of the leading '.' to unify behaviour
     return root_dir, sub_dir


### PR DESCRIPTION
`git rev-parse --show-toplevel` stops at first git repository, even if
it's a submodule of a parent repository.

This changes the path where the service is copied into the built
service container when running dmake from a submodule directory:
subtly breaking things (start script path and others are broken).

Could use `git rev-parse --show-superproject-working-tree` to check if
submodule, but only available since git 2.13 (2017-04), not available
by default on ubuntu 16.04.

Revert part of 8080b3fb602d1a0aa33f174ca0d0967840305b46