### PR TITLE
Add `volumes` at dmake.yml root: declare shared volumes by name

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -4,6 +4,7 @@ import logging
 import subprocess
 import re
 from ruamel.yaml import YAML
+import uuid
 
 # Set logger
 logger = logging.getLogger("deepomatic.dmake")
@@ -30,6 +31,11 @@ class DMakeException(Exception):
 class NotGitRepositoryException(DMakeException):
     def __init__(self):
         super(NotGitRepositoryException, self).__init__('Not a GIT repository')
+
+class SharedVolumeNotFoundException(DMakeException):
+    def __init__(self, name):
+        super(SharedVolumeNotFoundException, self).__init__("Unknown volume named '%s'" % (name))
+        self.name = name
 
 ###############################################################################
 
@@ -168,9 +174,12 @@ def init(_command, _root_dir, _app, _options):
     global build_description
     global command, options, uname
     global do_pull_config_dir
+    global session_id
     root_dir = os.path.join(_root_dir, '')
     command = _command
     options = _options
+
+    session_id = uuid.uuid4()
 
     config_dir = os.getenv('DMAKE_CONFIG_DIR', None)
     if config_dir is None:

--- a/deepomatic/dmake/utils/dmake_create_docker_shared_volume
+++ b/deepomatic/dmake/utils/dmake_create_docker_shared_volume
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Usage:
+# dmake_create_docker_shared_volume VOLUME_NAME [PERMISSIONS])
+#
+# Result:
+# Create a docker volume and save its name for later cleanup
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -ne 1 -a $# -ne 2 ]; then
+    dmake_fail "$0: Missing arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    exit 1
+fi
+
+set -e
+
+VOLUME_NAME=$1
+PERMISSIONS=$2
+docker volume create --name "${VOLUME_NAME}"
+
+
+if [ ! -z "${PERMISSIONS}" ]; then
+  # Proper permissions in volume
+  docker run --rm -v "${VOLUME_NAME}:/mnt" alpine:latest chmod ${PERMISSIONS} /mnt
+fi
+
+
+echo "${VOLUME_NAME}" >> ${DMAKE_TMP_DIR}/shared_volumes_to_remove.txt

--- a/deepomatic/dmake/utils/dmake_remove_docker_containers_and_images
+++ b/deepomatic/dmake/utils/dmake_remove_docker_containers_and_images
@@ -4,7 +4,7 @@
 # dmake_remove_docker_containers_and_images TMP_DIR
 #
 # Result:
-# Terminate the docker links.
+# Remove containers, images and volumes to remove.
 
 test "${DMAKE_DEBUG}" = "1" && set -x
 
@@ -27,5 +27,11 @@ fi
 if [ -f ${TMP_DIR}/images_to_remove.txt ]; then
     set +e
     docker rmi -f `cat ${TMP_DIR}/images_to_remove.txt` > /dev/null 2>&1
+    set -e
+fi
+
+if [ -f ${TMP_DIR}/shared_volumes_to_remove.txt ]; then
+    set +e
+    docker volume rm -f `cat ${TMP_DIR}/shared_volumes_to_remove.txt` > /dev/null 2>&1
     set -e
 fi

--- a/tutorial/web/deploy/test-shared-volumes.sh
+++ b/tutorial/web/deploy/test-shared-volumes.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Expect:
+# - /shared_volume2, shared with worker containers
+# - 2 worker variants containters started before us, by dependency
+
+set -e
+
+echo "Check worker shared volume"
+cat /shared_volume2/hello-from-worker.*
+test $(ls -1 /shared_volume2/hello-from-worker.* | wc -l) -eq 2

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -10,6 +10,11 @@ env:
       variables:
         AMQP_URL: amqp://1.2.3.4/prod
 
+volumes:
+  - shared_rabbitmq_var_lib
+  - name: shared_volume2
+  - unused_shared_volume
+
 docker:
   root_image:
     name: ubuntu
@@ -34,10 +39,14 @@ services:
       ports:
         - container_port: 8000
           host_port: 8000
+      volumes:
+        - source: shared_volume2
+          target: /shared_volume2
     tests:
       commands:
         - touch 'tag' # test shared environment for multiple commands test
         - test -f "tag"  # test command escaping
+        - deploy/test-shared-volumes.sh
         - >-
           ./manage.py test
           --verbosity=2 --noinput

--- a/tutorial/worker/deploy/test-shared-volumes.sh
+++ b/tutorial/worker/deploy/test-shared-volumes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Expect:
+# - /var/lib/rabbitmq shared with rabbitmq container
+# - /shared_volume2, shared with web container
+# - rabbitmq container started before us, by dependency
+# - web containter started after us, by dependency
+
+set -e
+
+echo "Check rabbitmq shared volume"
+# mnesia directory is created at rabbitmq startup
+test -d /var/lib/rabbitmq/mnesia
+
+echo "Write file for web"
+echo "hello from worker: ${HOSTNAME}" >> /shared_volume2/hello-from-worker.${HOSTNAME}

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -27,6 +27,8 @@ docker_links:
     link_name: rabbitmq
     probe_ports:
       - 5672/tcp
+    volumes:
+      - shared_rabbitmq_var_lib:/var/lib/rabbitmq
     testing_options: -e RABBITMQ_DEFAULT_VHOST=dev
     env:
       RABBITMQ_DEFAULT_USER: user
@@ -48,6 +50,11 @@ services:
           - ubuntu-1804
         entrypoint: deploy/entrypoint.sh
         start_script: deploy/start.sh
+      volumes:
+        - source: shared_rabbitmq_var_lib
+          target: /var/lib/rabbitmq
+        - shared_volume2:/shared_volume2
     tests:
       commands:
+        - ./deploy/test-shared-volumes.sh
         - ./bin/worker_test


### PR DESCRIPTION
Closes #135 

They can be used during the dmake session in any service (app service
or docker_link service).

They are deleted at the end of the dmake session.

Permissions in the create volumes are set to
`${DMAKE_UID}:${DMAKE_UID}` so app services can write; it may require
manual handling for permissions with `docker_link` services.

Usage:
=====

- `services[].config.volumes` now accept named shared volumes

In addition to object {container_volume, host_volume}, it now accepts
a string value: `<volume_name>:<container_path>`

The `<volume_name>` is the name of a shared volume declared in root
`volumes`.

- `docker_link[].volumes` now also accepts named shared volumes

In addition to `<host_path>:<container_path>` (which is still only
applied for shell, because we don't want persistence during tests), it
now accepts: `<volume_name>:<container_path>` (always applied (shell,
run, test)).

The `<volume_name>` is the name of a shared volume declared in root
`volumes`.

Merged implicit and explicit old volumes types for `docker_links` and
`services`: `VolumeMountSerializer`
Now both accept both object and string, but keep their specific
behavior for now (no breaking change):
- `docker_link`:
  - ignored when not in shell (we don't want persistence during tests:
  use named volumes if need to share volumes between services)
  - relative host paths are relative to dmake file
- `service`:
  - when used locally (not in ssh deploy), force host path to be
  relative to root_repo/.dmake/volumes, not sure why

Examples:
```
    volumes:
      - ./foo1:/foo1
      - /foo2:/foo2
      - container_volume: ./foo3
        host_volume: /foo3
      - container_volume: /foo4
        host_volume: /foo4
```
`foo1` and `foo3` forms are equivalent; `foo2` and `foo4` are
equivalent.

New alternative type for volumes: named shared volumes: `SharedVolumeMountSerializer`
Examples:
```
    volumes:
      - foo5:/foo5
      - source: foo6
        target: /foo6
```
`foo5` and `foo6` forms are equivalent.

See also `tutorial/` and deploy/test-shared-volumes.sh

Details:
=======

Create shared volumes on demand using core.py dependency resolution,
by creating 2 objects, and links between them:
- `SharedVolumeSerializer`: the shared volume declaration in root
  `volumes
- `SharedVolumeMountSerializer` the shared volume usage on
  `docker_link` and `service`

Services and docker_links depend on creating the shared volumes for
run, shell, test commands.
Added new command: `shared_volume`.