### PR TITLE
Add variables to k8s deploy template manifest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,10 @@ properties([
                description: 'The branch to check out. Only used when testing a directory different from deepomatic/dmake.'),
         string(name: 'DMAKE_APP_TO_TEST',
                defaultValue: '*',
-               description: 'Application to test. You can also specify a service name if there is no ambiguity. Use * to force the test of all applications.')
+               description: 'Application to test. You can also specify a service name if there is no ambiguity. Use * to force the test of all applications.'),
+        booleanParam(name: 'DMAKE_SKIP_TESTS',
+                     defaultValue: false,
+                     description: 'Skip tests if checked')
     ]),
     pipelineTriggers([])
 ])

--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -90,10 +90,13 @@ def escape_cmd(cmd):
 def wrap_cmd(cmd):
     return '"%s"' % cmd.replace('"', '\\"')
 
-def eval_str_in_env(cmd, env=None):
+def eval_str_in_env(value, env=None, strict=False):
     if env is None:
         env = {}
-    cmd = 'echo %s' % wrap_cmd(cmd)
+    cmd = ''
+    if strict:
+        cmd += 'set -euo pipefail; '
+    cmd += 'echo %s' % wrap_cmd(value)
     return run_shell_command(cmd, additional_env=env).strip()
 
 # Docker has some trouble mounting volumes with trailing '/'.


### PR DESCRIPTION
Add optional template variables for kubernetes deployment manifest

Usage:
- in `dmake.yml`:
```
env:
  branches:
    default:
      variables:
        K8S_DEPLOY_TLS_SECRET_NAME: dev-tls-secret
    master:
      variables:
        K8S_DEPLOY_TLS_SECRET_NAME: prod-tls-secret
...
services:
  - deploy:
      stages:
        - kubernetes:
            manifest:
              template: deploy/kubernetes-deploy.yaml
              variables:
                TLS_SECRET_NAME: ${K8S_DEPLOY_TLS_SECRET_NAME}
```
- in `deploy/kubernetes-deploy.yaml`:
```

apiVersion: extensions/v1beta1
kind: Ingress
...
spec:
  tls:
    - secretName: ${TLS_SECRET_NAME}
  backend:
    serviceName: web
    servicePort: 80
```

Still support the simple version where
`services[].deploy.stages[].kubernetes.manifest` is directly a file
path to the manifest.

Also add optional strict mode for `common.eval_str_in_env`: raise error when using undefined variable: using it in `manifest.variables` to avoid typo errors that convert to empty strings, which is valid in k8s manifest: error would happen too late in the cluster.