### PR TITLE
Support `need_gpu` on all services, for all local executions.

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -164,6 +164,7 @@ def init(_command, _root_dir, _app, _options):
     global root_dir, tmp_dir, config_dir, cache_dir, relative_cache_dir, key_file
     global branch, target, is_pr, pr_id, build_id, commit_id, force_full_deploy
     global repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
+    global no_gpu
     global build_description
     global command, options, uname
     global do_pull_config_dir
@@ -193,6 +194,9 @@ def init(_command, _root_dir, _app, _options):
 
     # Set skip test variable
     skip_tests = os.getenv('DMAKE_SKIP_TESTS', "false") in ["1", "true"]
+
+    # Set no_gpu variable
+    no_gpu = os.getenv('DMAKE_NO_GPU', "false") in ["1", "true"]
 
     # Currently set if any dmake file describes a deploy stage matching current branch; updated after files parsing
     is_release_branch = None

--- a/deepomatic/dmake/utils/dmake_run_docker
+++ b/deepomatic/dmake/utils/dmake_run_docker
@@ -48,4 +48,10 @@ if [ ! -z "${TMP_DIR}" ]; then
     echo ${NAME} >> ${TMP_DIR}/containers_to_remove.txt
 fi
 
-docker run --name ${NAME} "$@"
+# support some GPU modes using nvidia docker v2
+DOCKER_RUN_ARGS=( run )
+if [[ "${DMAKE_DOCKER_RUN_WITH_GPU}" == "all" ]]; then
+  DOCKER_RUN_ARGS+=( --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all )
+fi
+
+docker "${DOCKER_RUN_ARGS[@]}" --name ${NAME} "$@"


### PR DESCRIPTION
Closes #140 

- added `need_gpu` on `docker_links[]` (in addition to previous
  `services[].config`)
- use `need_gpu` on local executions: run, run_link, test, shell
  (in addition to previous ssh deploy)

Locally we now use nvidia docker v2 with:
`docker run --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all`

This allows using GPU on any docker image (not just `FROM
nvidia/cuda`).

If local machine doesn't support nvidia docker v2, then GPU support
can be disabled with `export DMAKE_NO_GPU=1`: the services will be run
without GPU, it could break things: it's the user's responsibility.