### PR TITLE
Add a Jenkins lock on 'GPU' when testing services that need one

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -164,7 +164,7 @@ def init(_command, _root_dir, _app, _options):
     global root_dir, tmp_dir, config_dir, cache_dir, relative_cache_dir, key_file
     global branch, target, is_pr, pr_id, build_id, commit_id, force_full_deploy
     global repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
-    global no_gpu
+    global no_gpu, need_gpu
     global build_description
     global command, options, uname
     global do_pull_config_dir
@@ -197,6 +197,7 @@ def init(_command, _root_dir, _app, _options):
 
     # Set no_gpu variable
     no_gpu = os.getenv('DMAKE_NO_GPU', "false") in ["1", "true"]
+    need_gpu = False
 
     # Currently set if any dmake file describes a deploy stage matching current branch; updated after files parsing
     is_release_branch = None

--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -24,6 +24,10 @@ def append_command(commands, cmd, prepend = False, **args):
         check_cmd(args, ['name', 'concurrency'])
     elif cmd == "stage_end":
         check_cmd(args, [])
+    elif cmd == "lock":
+        check_cmd(args, ['resource'])
+    elif cmd == "lock_end":
+        check_cmd(args, [])
     elif cmd == "echo":
         check_cmd(args, ['message'])
     elif cmd == "sh":
@@ -81,6 +85,7 @@ def get_docker_run_gpu_cmd_prefix(need_gpu, service_type, service_name):
             common.logger.info("GPU needed by %s '%s' but DMAKE_NO_GPU set: trying without GPU." % (service_type, service_name))
             pass
         else:
+            common.need_gpu = True
             prefix = 'DMAKE_DOCKER_RUN_WITH_GPU=all '
     return prefix
 


### PR DESCRIPTION
Closes #142 

In practice it wraps the whole `Testing App` stage with a
`lock('GPU'){...}` block if any used service (app or docker_link)
requested a gpu via `need_gpu`.

Limitations:
- `dmake shell` is not supported: it is currently split into the
`Deploy` stage instead of `Testing App`, so it's harder to include it
in the lock, and `dmake shell` is never used with the Jenkins pipeline
mode anyway.
- locking is not minimal: we lock the whole testing stage instead of
just when services needing a GPU are up; but it doesn't change much:
we currently have only optimal service start, not service stop, so we
would not gain much. Also, services dependencies are recursive, so we
often need the GPU the whole time anyway.