### PR TITLE
Cleanup `env` mess in generate_run

### DIFF
--- a/deepomatic/dmake/common.py
+++ b/deepomatic/dmake/common.py
@@ -96,12 +96,14 @@ def escape_cmd(cmd):
 def wrap_cmd(cmd):
     return '"%s"' % cmd.replace('"', '\\"')
 
-def eval_str_in_env(value, env=None, strict=False):
+def eval_str_in_env(value, env=None, strict=False, source=None):
     if env is None:
         env = {}
     cmd = ''
     if strict:
         cmd += 'set -euo pipefail; '
+    if source:
+        cmd += 'source %s && ' % (source)
     cmd += 'echo %s' % wrap_cmd(value)
     return run_shell_command(cmd, additional_env=env).strip()
 


### PR DESCRIPTION
(and other functions that use the same sub-functions)

Closes #145 

We previously evaluated 2 or 3 times the same env, and mixed
evaluation, additional envs, context env...

Now runtime env is computed once (in `_launch_options_()`), with
correct additional customization variables; and is passed up to all
others functions that could need it, to evaluate values elsewhere, and
to send the env to the containers.

- `context_env` is the same as `env`: the runtime env
- `customized_env` is in fact `additional_customization_variables`
- everything is evalualuated using the one runtime `env`

Bug fixes/behavior change:
- in `dmake shell` the `.build.env` values were previously wrongly
  evaluated in the runtime `.env` context. Now they are just evaluated
  from the dmake process environment (that was the goal of splitting
  build and runtime envs).
- `data_volumes[].source` was previously only evaluated in the
  `needed_service` customization env instead of the full runtime env
  when the service was `run` (vs `test` or `shell`) (could happen when
  used as a `needed_service` of another service that was executed with
  `dmake test` for example).

New features:
- deploy stage env is now evaluated in the context of runtime `env`,
  instead of just in the context of `env.source`: it came from code
  factorization, and I think it also makes more sense. It doesn't
  break anything: we never used variables there, just plain values.