### PR TITLE
K8s deploy prune

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -1176,7 +1176,7 @@ class DMakeFile(DMakeFileSerializer):
                     data = m.patch(data)
             if migrated:
                 with open(file, 'w') as f:
-                    common.yaml_ordered_dump(data, f)
+                    common.yaml_ordered_dump(data, f, normalize_indent=True)
                     common.logger.info("Migrations applied, please verify changes in '{}' and commit them.".format(file))
 
         except ValidationError as e:

--- a/deepomatic/dmake/kubernetes.py
+++ b/deepomatic/dmake/kubernetes.py
@@ -2,28 +2,44 @@ import hashlib
 import json
 import yaml
 
+import deepomatic.dmake.common as common
+
 def get_env_hash(env):
     """Return a stable hash for the `env` environment."""
     return hashlib.sha256(json.dumps(sorted(env.items()))).hexdigest()[:10]
 
-def generate_config_map(env, name):
+def generate_config_map(env, name, labels = None):
     """Return a kubernetes manifest defining a ConfigMap storing `env`."""
     data = yaml.load("""
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ""
+  labels: {}
 data: {}
 """)
     data['metadata']['name'] = name
+    if labels:
+        data['metadata']['labels'] = labels
     data['data'] = env
     return data
 
-def generate_config_map_file(env, name_prefix, output_filepath):
+def generate_config_map_file(env, name_prefix, output_filepath, labels = None):
     """Generate a ConfigMap manifest file with unique env-hashed name, and return the name."""
     env_hash = get_env_hash(env)
     name = "%s-env-%s" % (name_prefix, env_hash)
-    data = generate_config_map(env, name)
+    data = generate_config_map(env, name, labels)
     with open(output_filepath, 'w') as configmap_file:
         yaml.dump(data, configmap_file, default_flow_style=False)
     return name
+
+def add_labels(resource, labels):
+    if 'labels' not in resource['metadata']:
+        resource['metadata']['labels'] = {}
+    resource['metadata']['labels'].update(labels)
+
+def dump_all_str_and_add_labels(data_str, file, labels):
+    data = common.yaml_ordered_load(data_str, all=True)
+    for resource in data:
+        add_labels(resource, labels)
+    common.yaml_ordered_dump(data, file, all=True)

--- a/deepomatic/dmake/serializer.py
+++ b/deepomatic/dmake/serializer.py
@@ -269,7 +269,7 @@ class FieldSerializer(object):
         infos.append(type_str)
 
         if self.default is not None:
-            infos.append('default = %s' % common.yaml_ordered_dump(self.default, default_flow_style=True).strip())
+            infos.append('default = %s' % common.yaml_ordered_dump(self.default, normalize_indent=True, default_flow_style=True).strip())
 
         return infos, help_text, doc_string
 

--- a/deepomatic/dmake/utils/dmake_deploy_kubernetes
+++ b/deepomatic/dmake/utils/dmake_deploy_kubernetes
@@ -27,9 +27,14 @@ COMMIT=$1; shift
 
 BASE_ARGS=( --context=${CONTEXT} ${NAMESPACE:+--namespace=${NAMESPACE}} )
 
+FILES_NO_PRUNING_ARGS=( )
 FILES_ARGS=( )
 for file in "$@"; do
-  FILES_ARGS[${#FILES_ARGS[*]}]="--filename=${TMP_DIR}/${file}"
+  if [[ "${file}" == "no-pruning:"* ]]; then
+    FILES_NO_PRUNING_ARGS+=( --filename="${TMP_DIR}/${file#no-pruning:}" )
+  else
+    FILES_ARGS+=( --filename="${TMP_DIR}/${file}" )
+  fi
 done
 
 
@@ -41,10 +46,29 @@ function echo_title() {
 deploy_timestamp=$(date --iso-8601=seconds)
 
 echo_title Apply ${SERVICE} to kubernetes cluster ${CONTEXT}:
+
 # --record=false allows to specify `kubernetes.io/change-cause` annotation from the manifest files
-APPLY_ARGS=( "${BASE_ARGS[@]}" apply --record=false --output=yaml "${FILES_ARGS[@]}" )
+APPLY_BASE_ARGS=( "${BASE_ARGS[@]}" apply --record=false --output=yaml )
+if [[ "${DMAKE_K8S_DRY_RUN}" == "1" ]]; then
+  APPLY_BASE_ARGS+=( --dry-run )
+fi
+# first, non-pruned resources
+APPLY_NO_PRUNING_ARGS=( "${APPLY_BASE_ARGS[@]}" "${FILES_NO_PRUNING_ARGS[@]}" )
+
+echo kubectl "${APPLY_NO_PRUNING_ARGS[@]}"
+kubectl "${APPLY_NO_PRUNING_ARGS[@]}"
+
+# second, normal resources (we prune them)
+SELECTOR="dmake.deepomatic.com/service=${SERVICE},dmake.deepomatic.com/prune!=no-pruning"
+APPLY_ARGS=( "${APPLY_BASE_ARGS[@]}" --prune=true --cascade=true --selector="${SELECTOR}" "${FILES_ARGS[@]}" )
+
 echo kubectl "${APPLY_ARGS[@]}"
 kubectl "${APPLY_ARGS[@]}"
+
+if [[ "${DMAKE_K8S_DRY_RUN}" == "1" ]]; then
+  echo "dry-run, exiting"
+  exit
+fi
 
 echo_title Annotate ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
 # TODO currently not atomic: multiple apply can work in parallel, and this command may annotate the wrong version
@@ -65,6 +89,6 @@ echo kubectl "${ROLLOUT_STATUS_ARGS[@]}"
 kubectl "${ROLLOUT_STATUS_ARGS[@]}"
 
 echo_title New state of ${SERVICE} on kubernetes cluster ${CONTEXT}:
-GET_ARGS=( "${BASE_ARGS[@]}" get --output=wide "${FILES_ARGS[@]}" )
+GET_ARGS=( "${BASE_ARGS[@]}" get --output=wide "${FILES_NO_PRUNING_ARGS[@]}" "${FILES_ARGS[@]}" )
 echo kubectl "${GET_ARGS[@]}"
 kubectl "${GET_ARGS[@]}"

--- a/deepomatic/dmake/utils/dmake_deploy_kubernetes
+++ b/deepomatic/dmake/utils/dmake_deploy_kubernetes
@@ -84,9 +84,13 @@ ANNOTATE_ARGS=( "${BASE_ARGS[@]}" annotate deployment/${SERVICE} --overwrite=tru
 # kubectl "${ANNOTATE_ARGS[@]}"
 
 echo_title Rollout status for ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
-ROLLOUT_STATUS_ARGS=( "${BASE_ARGS[@]}" rollout status --watch=true deployment/${SERVICE} )
-echo kubectl "${ROLLOUT_STATUS_ARGS[@]}"
-kubectl "${ROLLOUT_STATUS_ARGS[@]}"
+
+DEPLOYMENTS=( $(kubectl get deployment --selector=dmake.deepomatic.com/service=${SERVICE} --output=jsonpath={.items..metadata.name}) )
+for DEPLOYMENT in ${DEPLOYMENTS[@]}; do
+  ROLLOUT_STATUS_ARGS=( "${BASE_ARGS[@]}" rollout status --watch=true deployment/${DEPLOYMENT} )
+  echo kubectl "${ROLLOUT_STATUS_ARGS[@]}"
+  kubectl "${ROLLOUT_STATUS_ARGS[@]}"
+done
 
 echo_title New state of ${SERVICE} on kubernetes cluster ${CONTEXT}:
 GET_ARGS=( "${BASE_ARGS[@]}" get --output=wide "${FILES_NO_PRUNING_ARGS[@]}" "${FILES_ARGS[@]}" )


### PR DESCRIPTION
 Add pruning to kubernetes deployment

Previously when removing a resource it leaked in the cluster, because
`kubectl apply` cannot know for sure what to remove.

The way to do it is to explicitly ask for pruning, and limit scope to
some resources via label selectors.
For it to work, we need to
- set a specific label to all resources (top level only because
  cascading handles that (e.g. Deploy -> RC -> Pod)), that
  scopes to the current dmake deployment: dmake app service_name:
  `dmake.deepomatic.com/service=<app>-<service_name>`
  (later it could be changed to deployment, when we add the concept of
  deployment independent of dmake service; the transition may be hard
  though.)
- and select on that when pruning (and when applying: both
  are done at the same time and both are impacted by the label
  selection).

The easiest way is to load the generate yamls, patch them, and
re-dump them, because we have multiple resources:
- env configmap: dmake generates it: we add proper labels directly
- user configmaps from files: dmake generates it but via
  `kubectl create configmap`, which doesn't support adding labels
  yet (see kubernetes/kubernetes#60295):
  we patch the yaml file.
- user manifest: fully under user control: we patch the yaml file.

For easier rollback at kubernetes level, we want to keep old env
configmaps. For that we:
- add a second label: `dmake.deepomatic.com/prune=no-pruning`
  (could add other values later if needed)
  for the dmake generated env configmap, to distinguish them from
  other resources in the same apply scope (dmake service)
- `kubectl apply` in two steps:
  - first for non-pruning manifests (the dmake generated env
    configmap), without `--prune`
  - second for all other manifests, with `--prune` (user
    manifests + user configmaps from files)
(We are forced to do two `kubectl apply` because the label selectors
apply both to the apply and prune parts.)


Bonus:
 Now wait all deployments rollouts instead of just the ~main one

Previously dmake imposed naming the "main" deployment ==
${SERVICE_NAME}, and waited only this deployment rollout.

Now we support multiple deployments: we discover them all with
the new injected label `dmake.deepomatic.com/service=${SERVICE_NAME}`,
then call `kubectl rollout status` on each (successively because
kubectl doesn't support multi resources for now).