### PR TITLE
Optionally build services with user-provided Dockerfile

### DIFF
--- a/deepomatic/dmake/deepobuild.py
+++ b/deepomatic/dmake/deepobuild.py
@@ -761,17 +761,11 @@ class DeployStageSerializer(YAML2PipelineSerializer):
     k8s_continuous_deployment = K8SCDDeploySerializer(optional = True, help_text = "Continuous deployment via Kubernetes. Look for all the deployments running this service.")
     kubernetes    = KubernetesDeploySerializer(optional = True, help_text = "Deploy to Kubernetes cluster.")
 
-class ServiceDockerSerializer(YAML2PipelineSerializer):
+class ServiceDockerCommonSerializer(YAML2PipelineSerializer):
     name             = FieldSerializer("string", optional = True, help_text = "Name of the docker image to build. By default it will be {:app_name}-{:service_name}. If there is no docker user, it won be pushed to the registry. You can use environment variables.")
     base_image_variant = FieldSerializer(["string", "array"], optional = True, child = "string", help_text = "Specify which `base_image` variants are used as `base_image` for this service. Array: multi-variant service. Default: first 'docker.base_image'.")
     check_private    = FieldSerializer("bool",   default = True,  help_text = "Check that the docker repository is private before pushing the image.")
     tag              = FieldSerializer("string", optional = True, help_text = "Tag of the docker image to build. By default it will be '[{:variant}-]{:branch_name}-{:build_id}'")
-    workdir          = FieldSerializer("dir",    optional = True, help_text = "Working directory of the produced docker file, must be an existing directory. By default it will be directory of the dmake file.")
-    copy_directories = FieldSerializer("array", child = "dir", default = [], help_text = "Directories to copy in the docker image.")
-    install_script   = FieldSerializer("file", child_path_only = True, executable = True, optional = True, example = "install.sh", help_text = "The install script (will be run in the docker). It has to be executable.")
-    entrypoint       = FieldSerializer("file", child_path_only = True, executable = True, optional = True, help_text = "Set the entrypoint of the docker image generated to run the app.")
-    start_script     = FieldSerializer("file", child_path_only = True, executable = True, optional = True, example = "start.sh", help_text = "The start script (will be run in the docker). It has to be executable.")
-    # v2: user provided Dockerfile
 
     def set_service(self, service):
         self.service = service
@@ -800,7 +794,32 @@ class ServiceDockerSerializer(YAML2PipelineSerializer):
         image_name = name + ":" + tag
         return image_name
 
-    def generate_build_docker(self, commands, path_dir, docker_base, build, config):
+    def is_runnable(self):
+        return self._is_runnable()
+
+    def _is_runnable(self):
+        # pure virtual method, implemented in children classes
+        raise NotImplementedError()
+
+    def generate_build_docker(self, commands, path_dir, docker_base, build):
+        self._generate_build_docker(commands, path_dir, docker_base, build)
+
+    def _generate_build_docker(self, commands, path_dir, docker_base, build):
+        # pure virtual method, implemented in children classes
+        raise NotImplementedError()
+
+class ServiceDockerV1Serializer(ServiceDockerCommonSerializer):
+    # v1: dmake generated Dockerfile
+    workdir          = FieldSerializer("dir",    optional = True, help_text = "Working directory of the produced docker file, must be an existing directory. By default it will be directory of the dmake file.")
+    copy_directories = FieldSerializer("array", child = "dir", default = [], help_text = "Directories to copy in the docker image.")
+    install_script   = FieldSerializer("file", child_path_only = True, executable = True, optional = True, example = "install.sh", help_text = "The install script (will be run in the docker). It has to be executable.")
+    entrypoint       = FieldSerializer("file", child_path_only = True, executable = True, optional = True, help_text = "Set the entrypoint of the docker image generated to run the app.")
+    start_script     = FieldSerializer("file", child_path_only = True, executable = True, optional = True, example = "start.sh", help_text = "The start script (will be run in the docker). It has to be executable.")
+
+    def _is_runnable(self):
+        return self.start_script is not None
+
+    def _generate_build_docker(self, commands, path_dir, docker_base, build):
         tmp_dir = common.run_shell_command('dmake_make_tmp_dir')
         common.run_shell_command('mkdir %s' % os.path.join(tmp_dir, 'app'))
 
@@ -822,7 +841,7 @@ class ServiceDockerSerializer(YAML2PipelineSerializer):
             workdir = os.path.join(mount_point, workdir)
             f.write('WORKDIR %s\n' % workdir)
 
-            for port in config.ports:
+            for port in self.service.config.ports:
                 f.write('EXPOSE %s\n' % port.container_port)
 
             if build.has_value():
@@ -851,7 +870,55 @@ class ServiceDockerSerializer(YAML2PipelineSerializer):
                 f.write('ENTRYPOINT ["%s"]\n' % os.path.join(mount_point, path_dir, self.entrypoint))
 
         image_name = self.get_image_name()
-        append_command(commands, 'sh', shell = 'dmake_build_docker "%s" "%s"' % (tmp_dir, image_name))
+        append_command(commands, 'sh', shell = 'dmake_build_docker "%s" "%s" --squash' % (tmp_dir, image_name))
+
+class ServiceDockerBuildSerializer(YAML2PipelineSerializer):
+    context    = FieldSerializer("dir", help_text = "Docker build context directory.", example = '.')
+    dockerfile = FieldSerializer("string", optional = True, help_text = "Alternate Dockerfile, relative path to `context` directory.", example = 'deploy/Dockerfile')
+    args       = FieldSerializer("dict", child = "string", default = {}, help_text = "Add build arguments, which are environment variables accessible only during the build process. Higher precedence than `.build.env`.", example = {'BUILD': '${BUILD}'})
+    labels     = FieldSerializer('dict', child="string", default = {}, help_text = "Add metadata to the resulting image using Docker labels. It's recommended that you use reverse-DNS notation to prevent your labels from conflicting with those used by other software.", example={'vendor': 'deepomatic'})
+
+    def _validate_(self, file, needed_migrations, data, field_name):
+        # also accept simple variant where data is a string: the `context` directory
+        if common.is_string(data):
+            data = {'context': data}
+        result = super(ServiceDockerBuildSerializer, self)._validate_(file, needed_migrations=needed_migrations, data=data, field_name=field_name)
+        # populate args
+        args = self.__fields__['args'].value
+        # variable substitution on args values from dmake process environment
+        for key in args:
+            args[key] = common.eval_str_in_env(args[key])
+        return result
+
+    def _serialize_(self, commands, path_dir, image_name, build_args):
+        program = 'dmake_build_docker'
+        args = [self.context, image_name]
+        # dockerfile
+        if self.dockerfile:
+            # in docker-compose the `dockerfile` path is relative to the `context`, we do the same in dmake; but in `docker image build the `--file` path is relative to CWD, not to `context`.
+            dockerfile_path = os.path.join(self.context, self.dockerfile)
+            args += ["--file=%s" % (dockerfile_path)]
+        # build arg
+        build_args.update(self.args)
+        args += ["--build-arg=%s=%s" % (key, value) for key, value in build_args.items()]
+        # labels
+        args += ["--label=%s=%s" % (key, value) for key, value in self.labels.items()]
+        cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
+        append_command(commands, 'sh', shell = cmd)
+
+class ServiceDockerV2Serializer(ServiceDockerCommonSerializer):
+    # v2: user provided Dockerfile
+    build            = ServiceDockerBuildSerializer(help_text = "Docker build options for service built using user-provided Dockerfile (ignore `.build.commands`), like in Docker Compose files.`")
+
+    def _is_runnable(self):
+        # assume the user-provided Dockerfile is a runnable service
+        return True
+
+    def _generate_build_docker(self, commands, path_dir, docker_base, build):
+        image_name = self.get_image_name()
+        base_image_name = docker_base.get_docker_base_image(self.base_image_variant)
+        build_args = {'BASE_IMAGE': base_image_name}
+        self.build._serialize_(commands, path_dir, image_name, build_args)
 
 class ReadinessProbeSerializer(YAML2PipelineSerializer):
     command               = FieldSerializer("array", child = "string", default = [], example = ['cat', '/tmp/worker_ready'], help_text = "The command to run to check if the container is ready. The command should fail with a non-zero code if not ready.")
@@ -877,7 +944,7 @@ class ReadinessProbeSerializer(YAML2PipelineSerializer):
         return 'bash -c "%s"' % cmd
 
 class DeployConfigSerializer(YAML2PipelineSerializer):
-    docker_image       = ServiceDockerSerializer(help_text = "Docker to build for running and deploying.")
+    docker_image       = FieldSerializer([ServiceDockerV1Serializer(), ServiceDockerV2Serializer()], allow_null = True, help_text = "Docker to build for running and deploying.")
     docker_opts        = FieldSerializer("string", default = "", example = "--privileged", help_text = "Docker options to add.")
     need_gpu           = FieldSerializer("bool", default = False, help_text = "Whether the service needs to be run on a GPU node.")
     ports              = FieldSerializer("array", child = DeployConfigPortsSerializer(), default = [], help_text = "Ports to open.")
@@ -1259,7 +1326,7 @@ class DMakeFile(DMakeFileSerializer):
             env = {}
         mount_point = docker_base.mount_point
         if service is not None and \
-           service.config.docker_image.workdir is not None:
+           getattr(service.config.docker_image, 'workdir', None) is not None:
             workdir = common.join_without_slash(mount_point, service.config.docker_image.workdir)
         else:
             workdir = os.path.join(mount_point, self.__path__)
@@ -1315,7 +1382,7 @@ class DMakeFile(DMakeFileSerializer):
 
     def generate_run(self, commands, service_name, docker_links, service_customization):
         service = self._get_service_(service_name)
-        if service.config.docker_image.start_script is None:
+        if not service.config.docker_image.is_runnable():
             raise DMakeException("You need to specify a 'config.docker_image.start_script' when running service '%s'." % service_name)
 
         unique_service_name = service_name
@@ -1343,12 +1410,12 @@ class DMakeFile(DMakeFileSerializer):
 
     def generate_build_docker(self, commands, service_name):
         service = self._get_service_(service_name)
-        service.config.docker_image.generate_build_docker(commands, self.__path__, self.docker, self.build, service.config)
+        service.config.docker_image.generate_build_docker(commands, self.__path__, self.docker, self.build)
 
     def _launch_options_(self, commands, service, docker_links, run_base_image, mount_root_dir, additional_env = None, additional_env_variables = None):
         if additional_env is None:
             additional_env = {}
-        if run_base_image and service.config.docker_image.entrypoint is not None:
+        if run_base_image and getattr(service.config.docker_image, 'entrypoint', None) is not None:
             full_path_container = os.path.join(self.docker.mount_point,
                                                self.__path__,
                                                service.config.docker_image.entrypoint)
@@ -1412,6 +1479,6 @@ class DMakeFile(DMakeFileSerializer):
         if not service.deploy.has_value():
             # no deploy specified, nothing to generate for deploy
             return
-        if service.config.docker_image.start_script is None:
+        if not service.config.docker_image.is_runnable():
             raise DMakeException("You need to specify a 'config.docker_image.start_script' when deploying service '%s'." % service_name)
         service.deploy.generate_deploy(commands, self.app_name, self.env, service.config)

--- a/deepomatic/dmake/serializer.py
+++ b/deepomatic/dmake/serializer.py
@@ -25,6 +25,7 @@ class FieldSerializer(object):
             data_type,
             optional=False,
             default=None,
+            allow_null=False,
             blank=False,
             child=None,
             post_validation=lambda x: x,
@@ -55,6 +56,7 @@ class FieldSerializer(object):
         self.data_type = data_type
         self.optional = optional
         self.default = default
+        self.allow_null = allow_null
         self.blank = blank
         self.post_validation = post_validation
         self.child_path_only = child_path_only
@@ -70,7 +72,7 @@ class FieldSerializer(object):
         self.value = None
 
     def _validate_(self, file, needed_migrations, data, field_name):
-        if data is None:
+        if data is None and not self.allow_null:
             if not self.optional:
                 raise ValidationError("got 'Null', expected a value of type %s" % (" -OR-\n".join([str(t) for t in self.data_type])))
             else:

--- a/deepomatic/dmake/utils/dmake_build_docker
+++ b/deepomatic/dmake/utils/dmake_build_docker
@@ -1,14 +1,14 @@
 #!/bin/bash
 #
 # Usage:
-# dmake_build_docker TMP_DIR NAME
+# dmake_build_docker CONTEXT_DIR IMAGE_NAME ARGS...
 #
 # Result:
-# Build a docker given a ${TMP_DIR}/Dockerfile
+# Build a docker image named ${IMAGE_NAME} using build context ${CONTEXT_DIR}
 
 test "${DMAKE_DEBUG}" = "1" && set -x
 
-if [ $# -ne 2 ]; then
+if [ $# -lt 2 ]; then
     dmake_fail "$0: Missing arguments"
     exit 1
 fi
@@ -20,10 +20,9 @@ fi
 
 set -e
 
-TMP_DIR=$1
-NAME=$2
+CONTEXT_DIR=$1
+IMAGE_NAME=$2
+shift 2
 
-cd ${TMP_DIR}
-
-docker image build --squash --tag ${NAME} .
-echo ${NAME} >> ${DMAKE_TMP_DIR}/images_to_remove.txt
+docker image build "$@" --tag ${IMAGE_NAME} ${CONTEXT_DIR}
+echo ${IMAGE_NAME} >> ${DMAKE_TMP_DIR}/images_to_remove.txt

--- a/tutorial/worker/.dockerignore
+++ b/tutorial/worker/.dockerignore
@@ -1,0 +1,6 @@
+dmake.yml
+.dockerignore
+Dockerfile
+
+bin/
+**/*.pyc

--- a/tutorial/worker/Dockerfile
+++ b/tutorial/worker/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as builder
+
+WORKDIR /app/tutorial/worker
+
+COPY . .
+
+RUN make -j$(nproc) install prefix=/usr/local/worker
+ARG BUILD_HOSTNAME
+RUN echo build hostname: ${BUILD_HOSTNAME}
+
+
+FROM ${BASE_IMAGE} as runtime
+
+WORKDIR /app/tutorial/worker
+
+COPY --from=builder /usr/local/worker .
+
+CMD ["deploy/start.sh"]
+ENTRYPOINT ["/app/tutorial/worker/deploy/entrypoint.sh"]

--- a/tutorial/worker/Makefile
+++ b/tutorial/worker/Makefile
@@ -1,3 +1,6 @@
+SHELL:=/bin/bash
+prefix:=/usr/local
+
 all:
 	mkdir -p bin
 	g++ --std=c++11 -o bin/worker src/main.cpp src/app.cpp src/amqp_client.cpp -lrabbitmq -lSimpleAmqpClient -lglog -Wall -Wextra
@@ -5,3 +8,10 @@ all:
 
 test:
 	./bin/worker_test
+
+install: all
+	mkdir -p $(prefix)/bin
+	cp -f ./bin/worker $(prefix)/bin/
+	cp -f ./bin/worker_test $(prefix)/bin/
+	mkdir -p $(prefix)/deploy
+	cp -f ./deploy/{entrypoint.sh,start.sh,test-shared-volumes.sh} $(prefix)/deploy/

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -34,10 +34,6 @@ docker_links:
       RABBITMQ_DEFAULT_USER: user
       RABBITMQ_DEFAULT_PASS: password
 
-build:
-  commands:
-    - make
-
 services:
   - service_name: worker
     needed_links:
@@ -48,8 +44,15 @@ services:
         base_image_variant:
           - ubuntu-1604
           - ubuntu-1804
-        entrypoint: deploy/entrypoint.sh
-        start_script: deploy/start.sh
+        # short form: `build: .`
+        build:
+          context: .
+          dockerfile: Dockerfile
+          args:
+            BUILD_HOSTNAME: ${HOSTNAME}
+          labels:
+            vendor: "deepomatic"
+            com.deepomatic.version.is-on-premises: "false"
       volumes:
         - source: shared_rabbitmq_var_lib
           target: /var/lib/rabbitmq


### PR DESCRIPTION
Closes #139 

Add `build` to `.services[].config.docker_image`, subset of Docker
Compose `build` format.

`build` can take 2 forms:
- string: docker build context directory, relative to current
  `dmake.yml` file
- object:
  - `context`: docker build context directory, relative to current
    `dmake.yml` file
  - `dockerfile`: Alternate `Dockerfile`, relative to `context`
    directory
  - `args`: dictionary of docker build arguments
  - `labels`: dictionary of labels to add to the built image

Examples:
========

```
        build: .
```

```
        build:
          context: ./app
          dockerfile: deploy/Dockerfile
          args:
            BUILD_HOST: ${HOSTNAME}
          labels:
            vendor: deepomatic
```

More: see `tutorial/worker/dmake.yml`

Details:
=======
- when using user-provided Dockerfile for service docker image build,
all other build related options are ignored:
  - root `build` (`commands`, `env` (use `build.args` instead))
  - `docker_image.{workdir,copy_directories,install_script,entrypoint,start_script}`
- injects `BASE_IMAGE` build `ARG`: the dmake `docker.base_image`
  (docker image name+tag)
- finally rejects out-of-context file access: limited by raw docker
  build context
- finally supports `.dockerignore` files (at the build context root
  directory)
- finally supports multi-stage build for clean final image (see
  `tutorial/worker/Dockerfile`)

Implementation:
==============

`docker_image` now accepts 2 different objects:

- either v1 with dmake-generated Dockerfile
- or v2 with user-provided Dockerfile

Can't mix them.

Only strange things:
- `.build.commands` can be set, and will be ignored by v2 built
  services, as there may be other services that still use v1 build
- `docker_image.entrypoint and workdir` are used in dmake shell:
  cannot set them with v2 builds


Also had to fix/cleanup "path", "file", "dir" types.
=====

- Fix absolute paths with `child_path_only==True`: was previously just
  broken because of missing `:`
- Fix checking going "up" outside of scope (repo root or `dmake.yml`
  directory, depending on `child_path_only`) when only going up just
  once (`..`).
- Added comments and asserts on what I understood and used invariants

Use `os.path.relpath` to compute relative paths, normalize paths
everywhere, and check only at one location if relative path goes "up"
too much. It's much more robust and clear.

Also cleanup error messages: both original value and computed value.