### PR TITLE
Removing dependancy on base when no base image is provided

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -162,6 +162,11 @@ def activate_service_shared_volumes(loaded_files, service_providers, service):
 ###############################################################################
 
 def activate_base(base_variant):
+    if base_variant is None:
+        # base_variant is None when no base image is specified,
+        # (only root_image is)
+        # in which case we do not need to do anything
+        return []
     return [('base', base_variant, None)]
 
 ###############################################################################

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -939,7 +939,7 @@ class ReadinessProbeSerializer(YAML2PipelineSerializer):
 
         # Make the command with "" around parameters
         cmd = self.command[0] + ' ' + (' '.join([common.wrap_cmd(c) for c in self.command[1:]]))
-        cmd = """T=0; sleep %s; while [ %s ]; do echo "Running readyness probe"; %s; if [ "$?" = "0" ]; then exit 0; fi; T=$((T+%d)); sleep %d; done; exit 1;""" % (self.initial_delay_seconds, condition, cmd, period, period)
+        cmd = """T=0; sleep %s; while [ %s ]; do echo "Running readiness probe"; %s; if [ "$?" = "0" ]; then echo "... ready"; exit 0; fi; T=$((T+%d)); sleep %d; done; exit 1;""" % (self.initial_delay_seconds, condition, cmd, period, period)
         cmd = common.escape_cmd(cmd)
         return 'bash -c "%s"' % cmd
 

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -606,7 +606,7 @@ class SSHDeploySerializer(YAML2PipelineSerializer):
                'dmake_copy_template deploy/deploy_ssh/start_app.sh %s' % start_file
         common.run_shell_command(cmd)
 
-        cmd = 'dmake_deploy_ssh "%s" "%s" "%s" "%s" "%s"' % (tmp_dir, app_name, self.user, self.host, self.port)
+        cmd = 'dmake_deploy_ssh "%s" "%s" "%s" "%s" "%d"' % (tmp_dir, app_name, self.user, self.host, self.port)
         append_command(commands, 'sh', shell = cmd)
 
 class K8SCDDeploySerializer(YAML2PipelineSerializer):
@@ -842,7 +842,7 @@ class ServiceDockerV1Serializer(ServiceDockerCommonSerializer):
             f.write('WORKDIR %s\n' % workdir)
 
             for port in self.service.config.ports:
-                f.write('EXPOSE %s\n' % port.container_port)
+                f.write('EXPOSE %d\n' % port.container_port)
 
             if build.has_value():
                 for key, value in build.env.items():
@@ -931,15 +931,15 @@ class ReadinessProbeSerializer(YAML2PipelineSerializer):
             return ""
 
         if self.max_seconds > 0:
-            condition = "$T -le %s" % self.max_seconds
+            condition = "$T -le %d" % self.max_seconds
         else:
             condition = "1"
 
-        period = max(int(self.period_seconds), 1)
+        period = max(self.period_seconds, 1)
 
         # Make the command with "" around parameters
         cmd = self.command[0] + ' ' + (' '.join([common.wrap_cmd(c) for c in self.command[1:]]))
-        cmd = """T=0; sleep %s; while [ %s ]; do echo "Running readiness probe"; %s; if [ "$?" = "0" ]; then echo "... ready"; exit 0; fi; T=$((T+%d)); sleep %d; done; exit 1;""" % (self.initial_delay_seconds, condition, cmd, period, period)
+        cmd = """T=0; sleep {initial_delay:d}; while [ {condition} ]; do echo "Running readiness probe"; {cmd}; if [ "$?" = "0" ]; then echo "... ready"; exit 0; fi; T=$((T+{period:d})); sleep {period:d}; done; exit 1;""".format(initial_delay=self.initial_delay_seconds, condition=condition, cmd=cmd, period=period)
         cmd = common.escape_cmd(cmd)
         return 'bash -c "%s"' % cmd
 
@@ -958,9 +958,9 @@ class DeployConfigSerializer(YAML2PipelineSerializer):
         opts = []
         for ports in self.ports:
             if testing_mode:
-                opts.append("-p %s" % ports.container_port)
+                opts.append("-p %d" % ports.container_port)
             else:
-                opts.append("-p 0.0.0.0:%s:%s" % (ports.host_port, ports.container_port))
+                opts.append("-p 0.0.0.0:%d:%d" % (ports.host_port, ports.container_port))
 
         for volume in self.volumes:
             if isinstance(volume, SharedVolumeMountSerializer):

--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -124,11 +124,9 @@ class FieldSerializer(object):
                 raise WrongType("Expecting bool")
             return data
         elif data_type == "int":
-            if isinstance(data, int) or isinstance(data, float):
-                data = int(data)
             if not isinstance(data, int):
                 raise WrongType("Expecting int")
-            return str(data)
+            return data
         elif data_type == "string":
             if isinstance(data, int) or isinstance(data, float):
                 data = str(data)

--- a/tutorial/e2e/.dockerignore
+++ b/tutorial/e2e/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+dmake.yml
+deploy/Dockerfile

--- a/tutorial/e2e/deploy/Dockerfile
+++ b/tutorial/e2e/deploy/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN apt-get -y update && apt-get install -y --no-install-recommends \
+            curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/tutorial/e2e/dmake.yml
+++ b/tutorial/e2e/dmake.yml
@@ -1,0 +1,21 @@
+dmake_version: 0.1
+app_name: dmake-tutorial
+
+docker:
+  root_image:
+    name: ubuntu
+    tag: 16.04
+
+services:
+  - service_name: e2e
+    needed_services:
+     - service_name: web
+       link_name: web
+    config:
+      docker_image:
+        build:
+          context: .
+          dockerfile: ./deploy/Dockerfile
+    tests:
+      commands:
+        - curl -sSf "http://web:8000/api/factorial/?n=5"

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -44,6 +44,15 @@ services:
       ports:
         - container_port: 8000
           host_port: 8000
+      readiness_probe:
+        command:
+          - curl
+          - -sSf
+          - http://localhost:8000/
+          - -o
+          - /dev/null
+        period_seconds: 1
+        max_seconds: 10
       volumes:
         - source: shared_volume_web_and_workers
           target: /shared_volume_with_workers


### PR DESCRIPTION
Base images used to not be needed for simple use cases. This fixes a crash due to a bad dependency.