### PR TITLE
Set python3 as a low-priority alternative when using python3_requirements

### DIFF
--- a/dmake/templates/docker-base/install_pip3.sh
+++ b/dmake/templates/docker-base/install_pip3.sh
@@ -9,6 +9,8 @@
 if [ `which pip3 | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python3-setuptools python3-dev libffi-dev libssl-dev curl g++
+    # Sets python3 as a python alternative with a low priority
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 0
     curl https://bootstrap.pypa.io/get-pip.py | python3
     pip3 install --upgrade pip
 fi


### PR DESCRIPTION
When using `python3_requirements` python3 is installed but calling `python` in the base image would not work as python2 is not installed and python3 is not declared as a python alternative.

We fix it by declaring python3 as a low-priority alternative.