### PR TITLE
Add optional `link_name` to `needed_services`

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -103,7 +103,7 @@ def load_dmake_files_list():
 
 def add_service_provider(service_providers, service, file, needs = None, base_variant = None):
     """'service', 'needs' and 'base_variant' are all service names."""
-    common.logger.debug("add_service_provider: service: %s, variant: %s" % (service, base_variant))
+    common.logger.debug("add_service_provider: service: %s, needs: %s, variant: %s" % (service, needs, base_variant))
     if service in service_providers:
         existing_service_provider, _, _ = service_providers[service]
         if existing_service_provider != file:

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1406,7 +1406,7 @@ class DMakeFile(DMakeFileSerializer):
 
         docker_opts, image_name, env = self._generate_run_docker_opts_(commands, service, docker_links, additional_env_variables = additional_customization_env_variables)
         docker_opts += service.tests.get_mounts_opt(service_name, env)
-        docker_cmd = 'dmake_run_docker_daemon "%s" "" %s -i %s' % (unique_service_name, docker_opts, image_name)
+        docker_cmd = 'dmake_run_docker_daemon "%s" "%s" "" "" %s -i %s' % (self.app_name, unique_service_name, docker_opts, image_name)
         docker_cmd = service.get_docker_run_gpu_cmd_prefix() + docker_cmd
 
         # Run daemon

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1107,8 +1107,11 @@ class TestSerializer(YAML2PipelineSerializer):
                            index     = html['index'],
                            title     = html['title'],)
 
+
+allowed_link_name_pattern = re.compile("^[a-z0-9-]{1,63}$")  # too laxist, but easy to read
 class NeededServiceSerializer(YAML2PipelineSerializer):
     service_name    = FieldSerializer("string", help_text = "The name of the needed application part.", example = "worker-nn", no_slash_no_space = True)
+    link_name       = FieldSerializer("string", optional = True, example = "worker-nn", help_text = "Link name.")
     env             = FieldSerializer("dict", child = "string", optional = True, default = {}, help_text = "List of environment variables that will be set when executing the needed service.", example = {'CNN_ID': '2'})
 
     def __init__(self, **kwargs):
@@ -1117,36 +1120,50 @@ class NeededServiceSerializer(YAML2PipelineSerializer):
 
     def __str__(self):
         s = "%s" % (self.service_name)
+        if self.link_name:
+            s += " (%s)" % (self.link_name)
         if self._specialized:
             s += " -- env: %s" % (self.env)
         return s
 
     def __repr__(self):
-        return "NeededServiceSerializer(service_name=%r, env=%r)" % (self.service_name, self.env)
+        return "NeededServiceSerializer(service_name=%r, link_name=%r, env=%r)" % (self.service_name, self.link_name, self.env)
 
     def __eq__(self, other):
         # NeededServiceSerializer objects are equal if equivalent, to deduplicate their instances at runtime
         # objects are not comparable before the call to _validate_(), because fields are not populated yet
         assert self.__has_value__, "NeededServiceSerializer objects are not comparable before validation"
-        return self.service_name == other.service_name and self.env == other.env
+        # easiest implementation for now: handle different link_name as different needed_services; later should try to aggregate various link_names to one instance of NeededServiceSerializer in `service_customization`
+        return self.service_name == other.service_name \
+            and self.link_name == other.link_name \
+            and self.env == other.env
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     def __hash__(self):
-        # env is not hashable, so skipping it, it's OK, it will just be negligibly less efficient
-        return hash(self.service_name)
+        # object is not hashable before the call to _validate_(), because fields are not populated yet
+        assert self.__has_value__, "NeededServiceSerializer object is not hashable before validation"
+        if not hasattr(self, '_env_frozenset'):
+            self._env_frozenset = frozenset(self.env.items())
+        return hash((self.service_name, self.link_name, self._env_frozenset))
 
     def _validate_(self, file, needed_migrations, data, field_name):
         # also accept simple variant where data is a string: the service_name
         if common.is_string(data):
             data = {'service_name': data}
         result = super(NeededServiceSerializer, self)._validate_(file, needed_migrations=needed_migrations, data=data, field_name=field_name)
+        if self.link_name and \
+           not allowed_link_name_pattern.match(self.link_name):
+            raise ValidationError("Invalid link name '%s': only '[a-z0-9-]{1,63}' is allowed. " % (self.link_name))
         self._specialized = len(self.env) > 0
+        # a unique identifier that is the same for all equivalent NeededServices
+        self._id = hash(self)
+        common.logger.debug("NeededService _id: %s for %r" % (self._id, self))
         return result
 
     def get_service_name_unique_suffix(self):
-        return "--%s" % id(self) if self._specialized else ""
+        return "--%s" % (self._id) if self._specialized else ""
 
 class ServicesSerializer(YAML2PipelineSerializer):
     service_name    = FieldSerializer("string", default = "", help_text = "The name of the application part.", example = "api", no_slash_no_space = True)
@@ -1165,7 +1182,7 @@ class ServicesSerializer(YAML2PipelineSerializer):
         self.variant = None
         self.original_service_name = self.service_name
 
-        # populate back_link to this Service
+        # populate back-link to this Service
         self.config.docker_image.set_service(self)
         self.deploy.set_service(self)
 
@@ -1358,7 +1375,7 @@ class DMakeFile(DMakeFileSerializer):
 
     def _get_link_opts_(self, commands, service):
         if common.options.dependencies:
-            needed_links = service.needed_links
+            needed_links = service.needed_links + [ns.link_name for ns in service.needed_services if ns.link_name]
             if len(needed_links) > 0:
                 append_command(commands, 'read_sh', var = 'DOCKER_LINK_OPTS', shell = 'dmake_return_docker_links %s %s' % (self.app_name, ' '.join(needed_links)), fail_if_empty = True)
 
@@ -1396,6 +1413,7 @@ class DMakeFile(DMakeFileSerializer):
 
         unique_service_name = service_name
         additional_customization_env_variables = {}
+        link_name = None
         if service_customization:
             # customization variables will be evaluated later:
             #   by `env.get_replaced_variables()` in the wrong dmake file runtime `.env`, but sometimes OK thanks to needed_links env_exports
@@ -1403,10 +1421,11 @@ class DMakeFile(DMakeFileSerializer):
             additional_customization_env_variables = service_customization.env
             # daemon name: <app_name>/<service_name><optional_unique_suffix>; service_name already contains "<app_name>/"
             unique_service_name += service_customization.get_service_name_unique_suffix()
+            link_name = service_customization.link_name
 
         docker_opts, image_name, env = self._generate_run_docker_opts_(commands, service, docker_links, additional_env_variables = additional_customization_env_variables)
         docker_opts += service.tests.get_mounts_opt(service_name, env)
-        docker_cmd = 'dmake_run_docker_daemon "%s" "%s" "" "" %s -i %s' % (self.app_name, unique_service_name, docker_opts, image_name)
+        docker_cmd = 'dmake_run_docker_daemon "%s" "%s" "%s" "" %s -i %s' % (self.app_name, unique_service_name, link_name or "", docker_opts, image_name)
         docker_cmd = service.get_docker_run_gpu_cmd_prefix() + docker_cmd
 
         # Run daemon

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1115,6 +1115,15 @@ class NeededServiceSerializer(YAML2PipelineSerializer):
         super(NeededServiceSerializer, self).__init__(**kwargs)
         self._specialized = True
 
+    def __str__(self):
+        s = "%s" % (self.service_name)
+        if self._specialized:
+            s += " -- env: %s" % (self.env)
+        return s
+
+    def __repr__(self):
+        return "NeededServiceSerializer(service_name=%r, env=%r)" % (self.service_name, self.env)
+
     def __eq__(self, other):
         # NeededServiceSerializer objects are equal if equivalent, to deduplicate their instances at runtime
         # objects are not comparable before the call to _validate_(), because fields are not populated yet

--- a/dmake/utils/dmake_return_docker_links
+++ b/dmake/utils/dmake_return_docker_links
@@ -26,16 +26,16 @@ shift 1
 
 CACHE_DIR="${DMAKE_TMP_DIR}/links/${APP_NAME}"
 
-LINK_OPTS=""
-for LINK in "$@"; do
-    LINK_FILE="${CACHE_DIR}/${LINK}.link"
-    if [ -f "${LINK_FILE}" ]; then
-        dmake_check_daemons name "`cat ${CACHE_DIR}/$LINK.name`"
-        OPTS=`cat ${LINK_FILE}`
-        LINK_OPTS="${LINK_OPTS} ${OPTS}"
+LINK_OPTS=( )
+for LINK_NAME in "$@"; do
+    ID_FILE="${CACHE_DIR}/${LINK_NAME}.id"
+    if [ -f "${ID_FILE}" ]; then
+        dmake_check_daemons id ${CONTAINER_ID}
+        ID=`cat ${ID_FILE}`
+        LINK_OPTS+=( --link=${ID}:${LINK_NAME} )
     else
-        dmake_fail "Unexpected error: missing link $LINK"
+        dmake_fail "Unexpected error: missing link ${LINK_NAME}"
         exit 1
     fi
 done
-echo "${LINK_OPTS}"
+echo "${LINK_OPTS[@]}"

--- a/dmake/utils/dmake_run_docker
+++ b/dmake/utils/dmake_run_docker
@@ -5,7 +5,7 @@
 #
 # Result:
 # Run a docker and save its name in the list of containers. If name is empty, it will generate one
-# If NAME is non empty, it will be named this way.
+# If NAME is non empty, it will be named this way, otherwise it will default to a unique, readable generated name
 # If TMP_DIR is specified, the container entry will be recorded in this directory for further suppression
 
 test "${DMAKE_DEBUG}" = "1" && set -x

--- a/dmake/utils/dmake_run_docker_daemon
+++ b/dmake/utils/dmake_run_docker_daemon
@@ -1,10 +1,12 @@
 #!/bin/bash
 #
 # Usage:
-# ID=$(dmake_run_docker_daemon SERVICE_NAME NAME ARGS...)
+# ID=$(dmake_run_docker_daemon APP_NAME SERVICE_NAME LINK_NAME NAME ARGS...)
 #
 # Result:
-# Run a docker daemon and save its ID in the list of containers to remove and return the container ID
+# Run a docker daemon, save container ID to list of containers to stop and return the container ID
+# if SERVICE_NAME is non-empty, save container ID as the daemon for SERVICE_NAME (in the list of daemons ID)
+# if LINK_NAME is non-empty, save container ID as the link for LINK_NAME (in <app>/links/<LINK_NAME>.id)
 
 test "${DMAKE_DEBUG}" = "1" && set -x
 
@@ -21,9 +23,11 @@ fi
 
 set -e
 
-SERVICE_NAME=$1
-NAME=$2
-shift 2
+APP_NAME=$1; shift
+SERVICE_NAME=$1; shift
+LINK_NAME=$1; shift
+NAME=$1; shift
+
 
 CONTAINER_ID=`dmake_run_docker "" "${NAME}" -d "$@"`
 while [ 1 = 1 ]; do
@@ -43,6 +47,13 @@ done
 
 if [ ! -z "${SERVICE_NAME}" ]; then
     echo "${CONTAINER_ID} ${SERVICE_NAME}" >> ${DMAKE_TMP_DIR}/daemon_ids.txt
+fi
+
+if [ ! -z "${LINK_NAME}" ]; then
+  CACHE_DIR="${DMAKE_TMP_DIR}/links/${APP_NAME}"
+  ID_FILE="${CACHE_DIR}/${LINK_NAME}.id"
+  mkdir -p ${CACHE_DIR}
+  echo "${CONTAINER_ID}" > ${ID_FILE}
 fi
 
 echo $CONTAINER_ID

--- a/dmake/utils/dmake_run_docker_link
+++ b/dmake/utils/dmake_run_docker_link
@@ -27,10 +27,7 @@ PROBE_PORTS=$1; shift
 OPTIONS=( $@ )
 
 CACHE_DIR="${DMAKE_TMP_DIR}/links/${APP_NAME}"
-LINK_FILE="${CACHE_DIR}/${LINK_NAME}.link"
-NAME_FILE="${CACHE_DIR}/${LINK_NAME}.name"
-OPT_FILE="${CACHE_DIR}/${LINK_NAME}.conf"
-OPT_STR="${IMAGE_NAME} ${OPTIONS[@]}"
+ID_FILE="${CACHE_DIR}/${LINK_NAME}.id"
 
 mkdir -p ${CACHE_DIR}
 
@@ -64,10 +61,8 @@ if [ -z "${CONTAINER_ID}" ]; then
     done
 fi
 
-LINK_OPT="--link ${CONTAINER_ID}:${LINK_NAME}"
-echo ${OPT_STR} > ${OPT_FILE}
-echo ${LINK_OPT} > ${LINK_FILE}
-echo "${CONTAINER_NAME}" > ${NAME_FILE}
+
+echo "${CONTAINER_ID}" > ${ID_FILE}
 
 if [ "${PROBE_PORTS}" = "none" ]; then
     :
@@ -77,6 +72,7 @@ else
     fi
     if [ ! -z "${PROBE_PORTS}" ]; then
         ROOT=$(dirname $0)
+        LINK_OPT="--link ${CONTAINER_ID}:${LINK_NAME}"
         docker run --rm ${LINK_OPT} -v ${ROOT}/dmake_wait_for_it:/usr/bin/dmake_wait_for_it -v ${ROOT}/dmake_wait_for_it_wrapper:/usr/bin/dmake_wait_for_it_wrapper -i ubuntu dmake_wait_for_it_wrapper "${LINK_NAME}" "${PROBE_PORTS}"
     fi
 fi

--- a/dmake/utils/dmake_run_docker_link
+++ b/dmake/utils/dmake_run_docker_link
@@ -26,11 +26,6 @@ LINK_NAME=$1; shift
 PROBE_PORTS=$1; shift
 OPTIONS=( $@ )
 
-CACHE_DIR="${DMAKE_TMP_DIR}/links/${APP_NAME}"
-ID_FILE="${CACHE_DIR}/${LINK_NAME}.id"
-
-mkdir -p ${CACHE_DIR}
-
 BASE_NAME=${REPO}.${BRANCH}.${BUILD}.${APP_NAME}.${LINK_NAME}
 
 COUNT=0
@@ -42,27 +37,9 @@ while [ 1 = 1 ]; do
     COUNT=$(($COUNT+1))
 done
 
-if [ -z "${CONTAINER_ID}" ]; then
-    docker pull ${IMAGE_NAME} 2> /dev/null || :
-    CONTAINER_ID=$(dmake_run_docker_daemon "" "${CONTAINER_NAME}" ${OPTIONS[@]} ${VOLUMES} -i ${IMAGE_NAME})
-    while [ 1 = 1 ]; do
-        if [ `docker ps -f id=$CONTAINER_ID -f status=running | wc -l` -gt "0" ]; then
-            break
-        fi
-        if [ `docker ps -a -f id=$CONTAINER_ID -f status=exited | wc -l` -gt "0" ]; then
-            echo "Link ${LINK_NAME} exited"
-            exit 1
-        fi
-        if [ `docker ps -a -f id=$CONTAINER_ID -f status=restarting | wc -l` -gt "0" ]; then
-            echo "Link ${LINK_NAME} is restarting"
-            exit 1
-        fi
-        sleep 1
-    done
-fi
+docker pull ${IMAGE_NAME} 2> /dev/null || :
+CONTAINER_ID=$(dmake_run_docker_daemon "${APP_NAME}" "" "${LINK_NAME}" "${CONTAINER_NAME}" ${OPTIONS[@]} ${VOLUMES} -i ${IMAGE_NAME})
 
-
-echo "${CONTAINER_ID}" > ${ID_FILE}
 
 if [ "${PROBE_PORTS}" = "none" ]; then
     :

--- a/tutorial/web/deploy/dependencies.sh
+++ b/tutorial/web/deploy/dependencies.sh
@@ -2,5 +2,6 @@
 set -e
 
 apt-get update
-apt-get --no-install-recommends -y install make
-
+apt-get --no-install-recommends -y install \
+        make \
+        iputils-ping

--- a/tutorial/web/deploy/test-needed-service-link.sh
+++ b/tutorial/web/deploy/test-needed-service-link.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+echo "Check needed_service link_name"
+
+HOST=$1
+
+ping -c1 $HOST

--- a/tutorial/web/deploy/test-shared-volumes.sh
+++ b/tutorial/web/deploy/test-shared-volumes.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 # Expect:
-# - /shared_volume2, shared with worker containers
+# - ${SHARED_VOLUME_PATH}, shared with worker containers
 # - 2 worker variants containters started before us, by dependency
 
 set -e
 
+SHARED_VOLUME_PATH=$1
+
 echo "Check worker shared volume"
-cat /shared_volume2/hello-from-worker.*
-test $(ls -1 /shared_volume2/hello-from-worker.* | wc -l) -eq 2
+cat ${SHARED_VOLUME_PATH}/hello-from-worker.*
+test $(ls -1 ${SHARED_VOLUME_PATH}/hello-from-worker.* | wc -l) -eq 2

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -12,7 +12,7 @@ env:
 
 volumes:
   - shared_rabbitmq_var_lib
-  - name: shared_volume2
+  - name: shared_volume_web_and_workers
   - unused_shared_volume
 
 docker:
@@ -30,8 +30,12 @@ services:
     needed_links:
       - rabbitmq
     needed_services:
-      - worker:ubuntu-1604
-      - worker:ubuntu-1804
+      - service_name: worker:ubuntu-1604
+        env:
+          TEST_SHARED_VOLUME: 1
+      - service_name: worker:ubuntu-1804
+        env:
+          TEST_SHARED_VOLUME: 1
     config:
       docker_image:
         entrypoint: deploy/entrypoint.sh
@@ -40,13 +44,13 @@ services:
         - container_port: 8000
           host_port: 8000
       volumes:
-        - source: shared_volume2
-          target: /shared_volume2
+        - source: shared_volume_web_and_workers
+          target: /shared_volume_with_workers
     tests:
       commands:
         - touch 'tag' # test shared environment for multiple commands test
         - test -f "tag"  # test command escaping
-        - deploy/test-shared-volumes.sh
+        - deploy/test-shared-volumes.sh /shared_volume_with_workers
         - >-
           ./manage.py test
           --verbosity=2 --noinput

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -34,6 +34,7 @@ services:
         env:
           TEST_SHARED_VOLUME: 1
       - service_name: worker:ubuntu-1804
+        link_name: worker-ubuntu-1804
         env:
           TEST_SHARED_VOLUME: 1
     config:
@@ -51,6 +52,7 @@ services:
         - touch 'tag' # test shared environment for multiple commands test
         - test -f "tag"  # test command escaping
         - deploy/test-shared-volumes.sh /shared_volume_with_workers
+        - deploy/test-needed-service-link.sh worker-ubuntu-1804
         - >-
           ./manage.py test
           --verbosity=2 --noinput

--- a/tutorial/worker/deploy/start.sh
+++ b/tutorial/worker/deploy/start.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
+if [ "${TEST_SHARED_VOLUME}" -eq 1 ]; then
+  echo "Write file for volume test"
+  echo "hello from worker: ${HOSTNAME}" >> /shared_volume/hello-from-worker.${HOSTNAME}
+fi
+
 exec ./bin/worker

--- a/tutorial/worker/deploy/test-shared-volumes.sh
+++ b/tutorial/worker/deploy/test-shared-volumes.sh
@@ -2,15 +2,10 @@
 
 # Expect:
 # - /var/lib/rabbitmq shared with rabbitmq container
-# - /shared_volume2, shared with web container
 # - rabbitmq container started before us, by dependency
-# - web containter started after us, by dependency
 
 set -e
 
 echo "Check rabbitmq shared volume"
 # mnesia directory is created at rabbitmq startup
 test -d /var/lib/rabbitmq/mnesia
-
-echo "Write file for web"
-echo "hello from worker: ${HOSTNAME}" >> /shared_volume2/hello-from-worker.${HOSTNAME}

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -56,7 +56,7 @@ services:
       volumes:
         - source: shared_rabbitmq_var_lib
           target: /var/lib/rabbitmq
-        - shared_volume2:/shared_volume2
+        - shared_volume_web_and_workers:/shared_volume
     tests:
       commands:
         - ./deploy/test-shared-volumes.sh


### PR DESCRIPTION
Closes #165 

When `link_name` is set, the needed service will be exposed to the dependent service
using docker links via `link_name` hostname, like with `needed_links`.

Details:
- pass new link_name to dmake_run_docker_daemon
- add needed_services link_names to docker links list

Easiest implementation for now: handle different link_name as
different needed_services; later we should try to aggregate various
link_names to one instance of NeededServiceSerializer in
`service_customization`.

Also some cleanup/fix/refactor:

- Cleanup/fix shared volumes tests in tutorials 
￼- More debug logs on NeededServices
- Cleanup/simplify docker_links runtime
- Refactor dmake_run_docker_link/dmake_run_daemon
- Add optional `link_name` to `needed_services` ￼
- Add needed_services link_name test in tutorial/