### PR TITLE
Jenkins Parameters for custom builds, evaluated for build args and labels

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -108,6 +108,10 @@ def eval_str_in_env(value, env=None, strict=False, source=None):
     cmd += 'echo %s' % wrap_cmd(value)
     return run_shell_command(cmd, additional_env=env).strip()
 
+def eval_values_in_env(d, env=None, strict=False, source=None):
+    for key in d:
+        d[key] = eval_str_in_env(d[key], env, strict, source)
+
 # Docker has some trouble mounting volumes with trailing '/'.
 # See http://stackoverflow.com/questions/38338612/mounting-file-system-in-docker-fails-sometimes
 def join_without_slash(*args):

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -1,3 +1,10 @@
+// default CUSTOM_ENVIRONMENT
+try {
+    default_custom_environment=DEFAULT_CUSTOM_ENVIRONMENT
+} catch (e) {
+    default_custom_environment=''
+}
+
 properties([
     parameters([
         string(name: 'DMAKE_APP',
@@ -5,7 +12,13 @@ properties([
                description: '(optional) Application to deploy. You can also specify a service name if there is no ambiguity. Use * to force the deployment of all applications. Leave empty for default behaviour.'),
         booleanParam(name: 'DMAKE_SKIP_TESTS',
                      defaultValue: false,
-                     description: 'Skip tests if checked')
+                     description: 'Skip tests if checked'),
+        booleanParam(name: 'DMAKE_DEBUG',
+                     defaultValue: false,
+                     description: 'Enable dmake debug logs'),
+        string(name: 'CUSTOM_ENVIRONMENT',
+               defaultValue: default_custom_environment,
+               description: '(optional) Custom environment variables, for custom build. Example: \'FOO=1 BAR=2\'')
     ]),
     pipelineTriggers([])
 ])
@@ -16,7 +29,11 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
               branches: scm.branches,
               extensions: scm.extensions + [[$class: 'SubmoduleOption', recursiveSubmodules: true]],
               userRemoteConfigs: scm.userRemoteConfigs])
-
-    sh 'dmake deploy "${DMAKE_APP}"'
+    // params are automatically exposed as environment variables
+    // but booleans to string generates "true"
+    if (params.DMAKE_DEBUG) {
+        env.DMAKE_DEBUG=1
+    }
+    sh "${params.CUSTOM_ENVIRONMENT} dmake deploy '${params.DMAKE_APP}'"
     load 'DMakefile'
 }

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -1,4 +1,22 @@
-// default CUSTOM_ENVIRONMENT
+// default parameters from dmake repo user
+try {
+    default_dmake_app=DEFAULT_DMAKE_APP
+} catch (e) {
+    default_dmake_app='*'
+}
+
+try {
+    default_dmake_skip_tests=DEFAULT_DMAKE_SKIP_TESTS
+} catch (e) {
+    default_dmake_skip_tests=false
+}
+
+try {
+    default_dmake_debug=DEFAULT_DMAKE_DEBUG
+} catch (e) {
+    default_dmake_debug=false
+}
+
 try {
     default_custom_environment=DEFAULT_CUSTOM_ENVIRONMENT
 } catch (e) {
@@ -8,13 +26,13 @@ try {
 properties([
     parameters([
         string(name: 'DMAKE_APP',
-               defaultValue: '*',
+               defaultValue: default_dmake_app,
                description: '(optional) Application to deploy. You can also specify a service name if there is no ambiguity. Use * to force the deployment of all applications. Leave empty for default behaviour.'),
         booleanParam(name: 'DMAKE_SKIP_TESTS',
-                     defaultValue: false,
+                     defaultValue: default_dmake_skip_tests,
                      description: 'Skip tests if checked'),
         booleanParam(name: 'DMAKE_DEBUG',
-                     defaultValue: false,
+                     defaultValue: default_dmake_debug,
                      description: 'Enable dmake debug logs'),
         string(name: 'CUSTOM_ENVIRONMENT',
                defaultValue: default_custom_environment,

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -8,7 +8,7 @@ try {
 properties([
     parameters([
         string(name: 'DMAKE_APP',
-               defaultValue: '',
+               defaultValue: '*',
                description: '(optional) Application to deploy. You can also specify a service name if there is no ambiguity. Use * to force the deployment of all applications. Leave empty for default behaviour.'),
         booleanParam(name: 'DMAKE_SKIP_TESTS',
                      defaultValue: false,

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -53,6 +53,7 @@ services:
           labels:
             vendor: "deepomatic"
             com.deepomatic.version.is-on-premises: "false"
+            build-host: "${HOSTNAME}"
       volumes:
         - source: shared_rabbitmq_var_lib
           target: /var/lib/rabbitmq


### PR DESCRIPTION
Closes #178

* service docker_image.build: variable substitution for labels in addition to args

Useful to pass custom build args via environment variables.

Also applied "strict" mode on both `args` and `labels`: they are new
options, we should always use "strict" for new options.
"strict" mode raises an error if an undefined variable is used, or if
an error happens during evaluation.

If you want to allow an undefined variable, then use `${MY_VAR:-}`; it
will evaluate to empty string (we have no way to unset...).

Evaluation is done at serialization time: only if the service is
really built, so it should not be too cumbersome to use.

* Add CUSTOM_BUILD_* parameters in Jenkins builds

Used for manual builds of on-premises images with special build args
and labels.