### PR TITLE
Add docker multi-stage build target

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -877,6 +877,7 @@ class ServiceDockerBuildSerializer(YAML2PipelineSerializer):
     dockerfile = FieldSerializer("string", optional = True, help_text = "Alternate Dockerfile, relative path to `context` directory.", example = 'deploy/Dockerfile')
     args       = FieldSerializer("dict", child = "string", default = {}, help_text = "Add build arguments, which are environment variables accessible only during the build process. Higher precedence than `.build.env`.", example = {'BUILD': '${BUILD}'})
     labels     = FieldSerializer('dict', child="string", default = {}, help_text = "Add metadata to the resulting image using Docker labels. It's recommended that you use reverse-DNS notation to prevent your labels from conflicting with those used by other software.", example={'vendor': 'deepomatic', 'build': '${BUILD}'})
+    target     = FieldSerializer("string", optional = True, help_text = "Build the specified stage as defined inside the Dockerfile. See the [multi-stage build docs](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) for details.", example = 'runtime')
 
     def _validate_(self, file, needed_migrations, data, field_name):
         # also accept simple variant where data is a string: the `context` directory
@@ -902,6 +903,9 @@ class ServiceDockerBuildSerializer(YAML2PipelineSerializer):
         args += ["--build-arg=%s=%s" % (key, value) for key, value in build_args.items()]
         # labels
         args += ["--label=%s=%s" % (key, value) for key, value in self.labels.items()]
+        # target
+        if self.target:
+            args.append("--target=%s" % (self.target))
         cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
         append_command(commands, 'sh', shell = cmd)
 

--- a/dmake/utils/dmake_build_docker
+++ b/dmake/utils/dmake_build_docker
@@ -7,6 +7,8 @@
 # Build a docker image named ${IMAGE_NAME} using build context ${CONTEXT_DIR}
 
 test "${DMAKE_DEBUG}" = "1" && set -x
+test "${DMAKE_DEBUG}" = "1" && DOCKER_BUILD_DEBUG=1
+
 
 if [ $# -lt 2 ]; then
     dmake_fail "$0: Missing arguments"
@@ -24,5 +26,5 @@ CONTEXT_DIR=$1
 IMAGE_NAME=$2
 shift 2
 
-docker image build "$@" --tag ${IMAGE_NAME} ${CONTEXT_DIR}
+docker ${DOCKER_BUILD_DEBUG:+--debug} image build "$@" --tag ${IMAGE_NAME} ${CONTEXT_DIR}
 echo ${IMAGE_NAME} >> ${DMAKE_TMP_DIR}/images_to_remove.txt

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -54,6 +54,7 @@ services:
             vendor: "deepomatic"
             com.deepomatic.version.is-on-premises: "false"
             build-host: "${HOSTNAME}"
+          target: runtime
       volumes:
         - source: shared_rabbitmq_var_lib
           target: /var/lib/rabbitmq


### PR DESCRIPTION
This permits re-using the same `Dockerfile` between multiple
services: factorize Dockerfile code, and better use of docker build
cache.

Example: prod with source, and on-premises without source.

Also extended DMAKE_DEBUG to call docker build with `--debug`. It
shows the ignored files via `.dockeringore`.