### PR TITLE
Add a non-interactive mode in install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ DMAKE_VERSION=0.1
 
 # TODO: we should turn all this script into a Python script
 QUIET=0
-if [ $1 == "--quiet" ]; then 
+if [ $1 == "--quiet" ]; then
   QUIET=1
 fi
 
@@ -38,7 +38,7 @@ function prompt {
 
 	# if quiet mode, leaves
         if [ "${QUIET}" == "1" ]; then
-            echo "Quiet mode activated, using '${DEFAULT}'" 
+            echo "Quiet mode activated, using '${DEFAULT}'"
             break
         fi
 
@@ -163,9 +163,9 @@ if [ -z "`which dmake`" ]; then
 else
     echo "Patched config to version ${DMAKE_VERSION}"
 fi
-    
+
 echo "Installing python dependencies with: pip install --user -r requirements.txt"
-pip install --user -r requirements.txt
+pip install --user -r $(dirname $0)/requirements.txt
 echo ""
 echo "You should be good to go !"
 echo "IMPORTANT: restart your shell session before testing the 'dmake' command !"

--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,9 @@ set -e
 DMAKE_VERSION=0.1
 
 # TODO: we should turn all this script into a Python script
-QUIET=0
-if [ $1 == "--quiet" ]; then
-  QUIET=1
+NON_INTERACTIVE=0
+if [ $1 == "--non-interactive" ]; then
+  NON_INTERACTIVE=1
 fi
 
 function prompt {
@@ -36,9 +36,9 @@ function prompt {
         # Ask question
         echo "${QUESTION}"
 
-	# if quiet mode, leaves
-        if [ "${QUIET}" == "1" ]; then
-            echo "Quiet mode activated, using '${DEFAULT}'"
+	# if non-interactive mode, leaves
+        if [ "${NON_INTERACTIVE}" == "1" ]; then
+            echo "Non-interactive mode activated, using '${DEFAULT}'"
             break
         fi
 

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,12 @@ set -e
 
 DMAKE_VERSION=0.1
 
+# TODO: we should turn all this script into a Python script
+QUIET=0
+if [ $1 == "--quiet" ]; then 
+  QUIET=1
+fi
+
 function prompt {
     QUESTION=$1
     VAR=$2
@@ -29,6 +35,13 @@ function prompt {
     while [ 1 ]; do
         # Ask question
         echo "${QUESTION}"
+
+	# if quiet mode, leaves
+        if [ "${QUIET}" == "1" ]; then
+            echo "Quiet mode activated, using '${DEFAULT}'" 
+            break
+        fi
+
         # Print options
         if [ ! -z "${OPTIONS}" ]; then
             N=${#OPTIONS[*]}
@@ -112,15 +125,15 @@ if [ -z "${DMAKE_SSH_KEY}" ]; then
     if [ -z "${KEYS}" ]; then
         while [ true ]; do
             DMAKE_SSH_KEY=
-            prompt "Please type in the path to the SSH key we should use to clone private repositories ?" "DMAKE_SSH_KEY"
-            if [ -f "${DMAKE_SSH_KEY}" ]; then
+            prompt "Please type in the path to the SSH key we should use to clone private repositories ?" "DMAKE_SSH_KEY" "" ""
+            if [ -f "${DMAKE_SSH_KEY}" ] || [ -z "${DMAKE_SSH_KEY}" ]; then
                 break
             else
                 echo "No such file: ${DMAKE_SSH_KEY} ! Again:"
             fi
         done
     else
-        prompt "Which SSH key should we use to clone private repositories ? (enter number)" "DMAKE_SSH_KEY" KEYS[@]
+        prompt "Which SSH key should we use to clone private repositories ? (enter number)" "DMAKE_SSH_KEY" KEYS[@] "${OPTIONS[0]}"
     fi
     DMAKE_SSH_KEY=$(echo ${DMAKE_SSH_KEY} | sed "s/\.pub//")
 fi
@@ -147,11 +160,12 @@ if [ -z "`which dmake`" ]; then
             echo "Patched ${SHRC} to source ${CONFIG_FILE}."
         fi
     done
-    echo "Install the python dependencies with the following command:"
-    echo "pip install --user -r requirements.txt"
-    echo "Then restart your shell session and test the 'dmake' command !"
 else
     echo "Patched config to version ${DMAKE_VERSION}"
-    echo "Update the python dependencies with the following command:"
-    echo "pip install --user -r requirements.txt"
 fi
+    
+echo "Installing python dependencies with: pip install --user -r requirements.txt"
+pip install --user -r requirements.txt
+echo ""
+echo "You should be good to go !"
+echo "IMPORTANT: restart your shell session before testing the 'dmake' command !"


### PR DESCRIPTION
This allow the automatic installation of dmake without asking questions for all system user with something like:
```
cd /home; for USER in `ls`; do su $USER -c "/usr/local/dmake/install.sh --non-interactive"; done
```
