### PR TITLE
Don't pollute `find` output with debug traces

### DIFF
--- a/dmake/utils/dmake_find
+++ b/dmake/utils/dmake_find
@@ -10,4 +10,4 @@
 
 test "${DMAKE_DEBUG}" = "1" && set -x
 
-{ LC_ALL=C find "$@" 3>&2 2>&1 1>&3 | { grep -v 'Permission denied' >&3; [ $? -eq 1 ]; } } 3>&2 2>&1
+{ LC_ALL=C find "$@" 2>&1 1>&3 | { grep -v 'Permission denied' 1>&2; [ $? -eq 1 ]; } } 3>&1


### PR DESCRIPTION
Closes #226.

Previous IO redirection was broken and accidentally applied to the
debug traces.

Before:
- swap stderr and stdout for `find`
- redirected `find` stdout is filtered by `grep`
- `grep` stdout is redirected back to line-global stderr
- line-global stderr is redirected to stdout <-- here we include
                                                 `set -x` traces
                                                 in stdout

After:
- `find` stdout redirected to fd `3`
- `find` stderr redirected to stdout
- redirected `find` stdout is filtered by `grep`
- `grep` stdout is redirected back to line-global stderr
- redirect fd `3` to line-global stdout

=> We never redirect fd `2` (which sometimes includes debug traces)
somewhere else, except for `find` stderr (which does *not* include
debug traces, just `find` stderr).

Previous version was OK when initially added by #21 because it was
isolated to just that line, without `set -x`; then #33 moved it to a
dmake util command: `dmake_find`: still working; then #44 added
`set -x`, revealing the bug. enter the commit message for your
changes.