### PR TITLE
Fix python3 kubernetes env hash

### DIFF
--- a/dmake/kubernetes.py
+++ b/dmake/kubernetes.py
@@ -6,7 +6,9 @@ import dmake.common as common
 
 def get_env_hash(env):
     """Return a stable hash for the `env` environment."""
-    return hashlib.sha256(json.dumps(sorted(env.items()))).hexdigest()[:10]
+    serialized_env = json.dumps(sorted(env.items()))
+    serialized_env_binary = common.to_string(serialized_env).encode('UTF-8')
+    return hashlib.sha256(serialized_env_binary).hexdigest()[:10]
 
 def generate_config_map(env, name, labels = None):
     """Return a kubernetes manifest defining a ConfigMap storing `env`."""


### PR DESCRIPTION
Fix this error when dmake is run with python3:
```
TypeError: Unicode-objects must be encoded before hashing
```

We did not catch this issue earlier because of #232 