### PR TITLE
Cache get root image digest in python3

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -14,9 +14,9 @@ logger.addHandler(logging.StreamHandler())
 ###############################################################################
 
 if sys.version_info >= (3, 0):
-    from dmake.python_3x import StringIO, is_string, to_string, read_input, subprocess_output_to_string
+    from dmake.python_3x import StringIO, is_string, to_string, read_input, subprocess_output_to_string, lru_cache
 else:
-    from dmake.python_2x import StringIO, is_string, to_string, read_input, subprocess_output_to_string
+    from dmake.python_2x import StringIO, is_string, to_string, read_input, subprocess_output_to_string, lru_cache
 
 ###############################################################################
 

--- a/dmake/docker_registry.py
+++ b/dmake/docker_registry.py
@@ -5,7 +5,7 @@ import requests
 import argparse
 import re
 
-from dmake.common import DMakeException, to_string
+from dmake.common import DMakeException, to_string, lru_cache, logger
 import dmake.docker_config as docker_config
 
 
@@ -73,8 +73,12 @@ def parse_docker_image(image):
 
     return namespace, name, tag
 
+
+@lru_cache()
 def get_image_digest(image):
     """Get image digest (sha256)"""
+    logger.debug('get_image_digest: %s', image)
+
     namespace, name, tag = parse_docker_image(image)
 
     # https://docs.docker.com/registry/spec/api/#pulling-an-image

--- a/dmake/python_2x.py
+++ b/dmake/python_2x.py
@@ -16,3 +16,10 @@ def subprocess_output_to_string(output):
     """Returns a python 2 str (bytes characters string)"""
     return output
 
+
+def lru_cache(**kwargs):
+
+    def decorator(target):
+        # not implemented in python 2: use python3
+        return target
+    return decorator

--- a/dmake/python_3x.py
+++ b/dmake/python_3x.py
@@ -2,6 +2,8 @@ from io import StringIO
 
 from collections import OrderedDict
 
+from functools import lru_cache
+
 class MetaYAML2PipelineSerialize(type):
     @classmethod
     def __prepare__(metacls, name, bases, **kwargs):


### PR DESCRIPTION
Closes #229 

If multiple services uses the same root_image, then only one docker
registry lookup will be done if dmake is run with python3.