### PR TITLE
Quickfix: in test mode, always test dependencies before running them

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -221,6 +221,8 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
             children += activate_base(base_variant)
         elif command == 'run':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
+            if common.command in ['test', 'deploy']:
+                children += activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)


### PR DESCRIPTION
Related to #243

Previously with `dmake test -d '*'` we did not guarantee steps order
between running a service as a dependency of another, and testing that
service.
This resulted in unwanted parallel execution of tests and run as
dependency.

Quickfix: always force testing a service before running it in test
mode (commands `test` and `deploy`).

Drawbacks:
- hardcoded `test` mode, we could use the dependency DAG to know if we
are in test mode instead
- when testing a service instead of `*`, we now also test its
dependencies services.