### PR TITLE
Add `dev` for development runtime configuration: `dmake shell`

### DIFF
--- a/test/worker/dmake.yml
+++ b/test/worker/dmake.yml
@@ -38,6 +38,8 @@ services:
   - service_name: test-worker
     needed_links:
       - rabbitmq
+    dev:
+      entrypoint: deploy/entrypoint.sh
     config:
       docker_image:
         name: dmake-test-worker

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -27,6 +27,8 @@ services:
   - service_name: worker
     needed_links:
       - rabbitmq
+    dev:
+      entrypoint: deploy/entrypoint.sh
     config:
       docker_image:
         build:


### PR DESCRIPTION
Closes #246 

For now only provides a `dmake shell`-dedicated entrypoint, that won't
leak into the service.

If entrypoints are defined both in service and in dev conf, the dev
conf takes precedence. If needed, we could later try to chain
both entrypoints.

Later we could have a `start_script` for dev (with auto
reload/rebuild) to start multiple services in development mode at the
same time (with service sources mounted from host into container).