### PR TITLE
Add --debug-graph global option: generate DOT graph of internal steps for the command

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -727,6 +727,11 @@ def make(options):
     sorted_leaves = filter(lambda a_b__c: a_b__c[0][0] == common.command, sorted_leaves)
     build_files_order = order_dependencies(service_dependencies, sorted_leaves)
 
+    common.dump_dot_graph(service_dependencies, build_files_order)
+    if common.exit_after_generate_dot_graph:
+        print('Exiting after debug graph generation')
+        sys.exit(0)
+
     # Sort by order
     ordered_build_files = sorted(build_files_order.items(), key = lambda file_order: file_order[1])
 

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -33,6 +33,12 @@ os.chdir(root_dir)
 
 # Defines command line parser
 argparser = argparse.ArgumentParser(prog='dmake')
+
+argparser.add_argument('--debug-graph', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes.")
+argparser.add_argument('--debug-graph-and-exit', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes then exit.")
+argparser.add_argument('--debug-graph-output-filename', default='dmake-services.gv', help="The generated DOT graph filename.")
+argparser.add_argument('--debug-graph-output-format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
+
 subparsers = argparser.add_subparsers(dest='cmd')
 subparsers.required = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests-oauthlib==0.8.0
 inquirer==2.2.0
 PyGithub==1.39
 semver==2.8.0
+graphviz==0.8.4


### PR DESCRIPTION
# New optional arguments:
```
  --debug-graph         Generate dmake steps DOT graph for debug purposes.
  --debug-graph-and-exit
                        Generate dmake steps DOT graph for debug purposes then
                        exit.
  --debug-graph-output-filename DEBUG_GRAPH_OUTPUT_FILENAME
                        The generated DOT graph filename.
  --debug-graph-output-format DEBUG_GRAPH_OUTPUT_FORMAT
                        The generated DOT graph format (`png`, `svg`, `pdf`,
                        ...).
```

# Output:
```
$ dmake --debug-graph-and-exit --debug-graph-output-format=svg test '*'
===============
REPO : dmake
BUILD : 0
BRANCH : dev-debug_graph
COMMIT_ID : 2c980c5
===============
Forcing full re-build
Generated debug DOT graph: 'dmake-services.gv' and 'dmake-services.gv.svg'
Exiting after debug graph generation
```
![dmake-services gv](https://user-images.githubusercontent.com/1730297/42217550-e9a5273e-7ec5-11e8-83bf-f4ca086dac6d.png)


# Use-case:
debug dmake itself.