### PR TITLE
Add `timeout` to services `tests`

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -443,6 +443,13 @@ def generate_command_pipeline(file, cmds):
         elif cmd == "lock_end":
             indent_level -= 1
             write_line("}")
+        elif cmd == "timeout":
+            time = kwargs['time']
+            write_line("timeout(time: %s, unit: 'SECONDS') {" % time)
+            indent_level += 1
+        elif cmd == "timeout_end":
+            indent_level -= 1
+            write_line("}")
         elif cmd == "echo":
             message = kwargs['message'].replace("'", "\\'")
             write_line("echo '%s'" % message)
@@ -551,6 +558,11 @@ def generate_command_bash(file, cmds):
             # lock not supported with bash
             pass
         elif cmd == "lock_end":
+            pass
+        elif cmd == "timeout":
+            # timeout not supported with bash
+            pass
+        elif cmd == "timeout_end":
             pass
         elif cmd == "echo":
             message = kwargs['message'].replace("'", "\\'")

--- a/test/e2e/dmake.yml
+++ b/test/e2e/dmake.yml
@@ -19,3 +19,4 @@ services:
     tests:
       commands:
         - curl -sSf "http://web:8000/api/factorial/?n=5"
+      timeout: 5

--- a/tutorial/e2e/dmake.yml
+++ b/tutorial/e2e/dmake.yml
@@ -19,3 +19,4 @@ services:
     tests:
       commands:
         - curl -sSf "http://web:8000/api/factorial/?n=5"
+      timeout: 5


### PR DESCRIPTION
Closes #194 

This is only implemented for Jenkins pipelines for now. This is useful
to protect against tests that never finish (or are abnormally slow).

Details:
- the timeout block is only applied around the `commands` execution:
  it excludes dependencies starting, volumes creation, GPU lock
  aquisition...
- on timeout, the whole pipeline is aborted, and the GPU lock is
  automatically released.