### PR TITLE
Fix tests commands escaping: should be passed as-is to container

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -111,6 +111,10 @@ def escape_cmd(cmd):
 def wrap_cmd(cmd):
     return '"%s"' % cmd.replace('"', '\\"')
 
+def wrap_cmd_simple_quotes(cmd):
+    # Example: foo'bar -> 'foo'\''bar' (i.e. 3 concatenated literal strings: 'foo', \' and 'bar', which is interpreted by bash as one arg: foo'bar)
+    return "'%s'" % cmd.replace("'", "'\\''")
+
 def eval_str_in_env(value, env=None, strict=False, source=None):
     if env is None:
         env = {}

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1122,7 +1122,7 @@ class TestSerializer(YAML2PipelineSerializer):
         if not self.has_value() or len(self.commands) == 0:
             return
 
-        tests_cmd = '/bin/bash -c %s' % common.wrap_cmd(' && '.join(self.commands))
+        tests_cmd = '/bin/bash -c %s' % common.wrap_cmd_simple_quotes(' && '.join(self.commands))
 
         has_timeout = self.timeout is not None
         if has_timeout:

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -6,6 +6,7 @@ env:
     variables:
       AMQP_URL: amqp://rabbitmq/dev
       SHARED_VOLUME_ROOT: /shared_volume_root_value
+      ENV_EVALUATION_TEST: foobar
   branches:
     master:
       variables:
@@ -59,6 +60,7 @@ services:
           target: ${SHARED_VOLUME_ROOT}/shared_volume_with_workers
     tests:
       commands:
+        - test "${ENV_EVALUATION_TEST}" = 'foobar' # test environment evaluation: should be evaluated in container
         - touch 'tag' # test shared environment for multiple commands test
         - test -f "tag"  # test command escaping
         - deploy/test-shared-volumes.sh /shared_volume_root_value/shared_volume_with_workers


### PR DESCRIPTION
Closes #272.

Using simple quotes to wrap the commands we guarantee it will arrive
as-is in the `docker run` command.