### PR TITLE
Add `env_exports` to `needed_services`

### DIFF
--- a/test/e2e/dmake.yml
+++ b/test/e2e/dmake.yml
@@ -11,6 +11,8 @@ services:
     needed_services:
      - service_name: test-web
        link_name: web
+       env_exports:
+         WEB_URL: http://web:8000
     config:
       docker_image:
         build:
@@ -18,5 +20,5 @@ services:
           dockerfile: ./deploy/Dockerfile
     tests:
       commands:
-        - curl -sSf "http://web:8000/api/factorial/?n=5"
+        - curl -sSf "${WEB_URL}/api/factorial/?n=5"
       timeout: 5

--- a/tutorial/e2e/dmake.yml
+++ b/tutorial/e2e/dmake.yml
@@ -11,6 +11,8 @@ services:
     needed_services:
      - service_name: web
        link_name: web
+       env_exports:
+         WEB_URL: http://web:8000
     config:
       docker_image:
         build:
@@ -18,5 +20,5 @@ services:
           dockerfile: ./deploy/Dockerfile
     tests:
       commands:
-        - curl -sSf "http://web:8000/api/factorial/?n=5"
+        - curl -sSf "${WEB_URL}/api/factorial/?n=5"
       timeout: 5


### PR DESCRIPTION
Closes #271 

This is only used by the parent service when constructing its runtime
environment.
Thus, it does not change how the needed service should be started,
thus we don't need to distinguish it from other instances of
NeededService to build the global commands DAG: just changed `__str__`
and `__repr__`, not `__ne__` nor `__hash__`.