### PR TITLE
Fix yaml dict list type check

### DIFF
--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -183,7 +183,7 @@ class FieldSerializer(object):
                         raise WrongType("Could not find directory: '%s' ('%s')" % (data, original_data))
             return data
         elif data_type == "array":
-            if not hasattr(data, '__iter__'):
+            if not isinstance(data, list):
                 raise WrongType("Expecting array")
             valid_data = []
             for d in data:
@@ -191,7 +191,7 @@ class FieldSerializer(object):
                 valid_data.append(child._validate_(file, needed_migrations=needed_migrations, data=d, field_name=field_name))
             return valid_data
         elif data_type == "dict":
-            if not hasattr(data, '__getitem__'):
+            if not isinstance(data, dict):
                 raise WrongType("Expecting dict")
             valid_data = {}
             for k, d in data.items():

--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -342,6 +342,8 @@ class YAML2PipelineSerializer(BaseYAML2PipelineSerializer):
             if self.__optional__:
                 return None
             data = {}
+        if not isinstance(data, dict):
+            raise WrongType("Expecting dict, got {}".format(type(data).__name__))
         for name, serializer in self.__fields__.items():
             try:
                 serializer._validate_(file,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ruamel.yaml==0.15.60
+ruamel.yaml==0.15.70
 kubernetes==4.0.0
 urllib3>=1.20
 backports.ssl-match-hostname>=3.5.0.1


### PR DESCRIPTION
* Fix yaml array detection by bumping ruamel.yaml

They now inherit again from `dict` and `list`.
This commit reverts back cb4e58b to
simple, proper type detection.

* Check for dict type when validating YAML2PipelineSerializer

This avoids accidentally matching strings that contain as substring
the name of an expected field.

Example:
```
$ cat dmake.yml
dmake_version: 0.1
app_name: test-repro

build: "string instead of object, containing the string 'commands' which' is an expected object key"

docker:
  root_image:
    name: ubuntu
    tag: 18.04

services: []
```

