### PR TITLE
Support multi GPU nodes when resource locking GPU in jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,22 @@ By the way, when there are multiple application in the same repository and multi
 $ dmake run -d dmake-tutorial/web
 ```
 
+## Using GPUs
+
+DMake supports services that need GPUs:
+Add `need_gpu: true` at the `service` `config` (or `docker_link`).
+
+It will run the service container with `docker run --runtime=nvidia`, using [NVIDIA docker 2](https://github.com/NVIDIA/nvidia-docker).
+
+By default it gives access to all GPUs available on the machine. You can restrict which GPU is used:
+```
+$ export DMAKE_GPU=2
+# or
+$ nvidia-smi -L
+GPU 0: GeForce GTX 1060 6GB (UUID: GPU-dfd9ebe0-1b0a-4cf9-a9c3-9edcd6a3449c)
+$ export DMAKE_GPU=GPU-dfd9ebe0-1b0a-4cf9-a9c3-9edcd6a3449c
+```
+
 ## Using DMake with Jenkins
 
 DMake can generate a `Jenkinsfile` instead of a `bash` file, allowing to execute dmake in [Jenkins](https://jenkins.io/), for continuous integration and deployment.
@@ -206,6 +222,17 @@ node {
 }
 ```
 - For example with github you can use github webhooks to setup continuous build, test, and deployment to kubernetes (with https://wiki.jenkins.io/display/JENKINS/GitHub+Branch+Source+Plugin).
+
+### Using GPUs with Jenkins
+
+Exclusive access to GPUs on the Jenkins node is implemented with the [Lockable Resources Plugin](https://wiki.jenkins.io/display/JENKINS/Lockable+Resources+Plugin) (`>=2.2`):
+Declare one resource per GPU, with the same label `GPUS`, and with GPU ID as name suffix (prefix: `GPU_`:
+- name: `GPU_0`, label: `GPUS`
+- name: `GPU_1`, label: `GPUS`
+Or:
+- name: `GPU_GPU-dfd9ebe0-1b0a-4cf9-a9c3-9edcd6a3449c`, label: `GPUS`
+- name: `GPU_GPU-9724ed88-599f-4212-80f6-d689849ad1e9`, label: `GPUS`
+
 
 ## Documentation
 

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -437,8 +437,8 @@ def generate_command_pipeline(file, cmds):
             indent_level -= 1
             write_line("}")
         elif cmd == "lock":
-            resource = kwargs['resource'].replace("'", "\\'")
-            write_line("lock('%s') {" % resource)
+            assert(kwargs['label'] == 'GPUS')
+            write_line("lock(label: 'GPUS', quantity: 1, variable: 'DMAKE_GPU') {")
             indent_level += 1
         elif cmd == "lock_end":
             indent_level -= 1
@@ -834,7 +834,7 @@ def make(options):
         # `common.need_gpu` is set during Testing commands generations: need to delay adding commands to all_commands to create the gpu lock if needed around the Testing stage
         lock_gpu = stage == "Testing App" and common.need_gpu
         if lock_gpu:
-            append_command(all_commands, 'lock', resource = 'GPU')
+            append_command(all_commands, 'lock', label='GPUS')
 
         all_commands += stage_commands
 

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -26,7 +26,7 @@ def append_command(commands, cmd, prepend = False, **args):
     elif cmd == "stage_end":
         check_cmd(args, [])
     elif cmd == "lock":
-        check_cmd(args, ['resource'])
+        check_cmd(args, ['label'])
     elif cmd == "lock_end":
         check_cmd(args, [])
     elif cmd == "timeout":
@@ -91,7 +91,7 @@ def get_docker_run_gpu_cmd_prefix(need_gpu, service_type, service_name):
             pass
         else:
             common.need_gpu = True
-            prefix = 'DMAKE_DOCKER_RUN_WITH_GPU=all '
+            prefix = 'DMAKE_DOCKER_RUN_WITH_GPU=yes '
     return prefix
 
 # ###############################################################################

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1426,11 +1426,12 @@ class DMakeFile(DMakeFileSerializer):
                 return t
         raise DMakeException("Could not find service '%s'" % service)
 
-    def _get_link_opts_(self, commands, service):
+    def _get_link_opts_(self, service):
         if common.options.dependencies:
             needed_links = service.needed_links + [ns.link_name for ns in service.needed_services if ns.link_name]
             if len(needed_links) > 0:
-                append_command(commands, 'read_sh', var = 'DOCKER_LINK_OPTS', shell = 'dmake_return_docker_links %s %s' % (self.app_name, ' '.join(needed_links)), fail_if_empty = True)
+                return 'dmake_return_docker_links %s %s' % (self.app_name, ' '.join(needed_links))
+        return None
 
     def _get_check_needed_services_(self, commands, service):
         if common.options.dependencies and len(service.needed_services) > 0:
@@ -1518,9 +1519,10 @@ class DMakeFile(DMakeFileSerializer):
         docker_opts += entrypoint_opt
 
         self._get_check_needed_services_(commands, service)
-        self._get_link_opts_(commands, service)
         docker_opts += " " + service.config.full_docker_opts(env, mount_host_volumes=False, use_host_ports=use_host_ports)
-        docker_opts += " ${DOCKER_LINK_OPTS}"
+        link_opts_command = self._get_link_opts_(service)
+        if link_opts_command is not None:
+            docker_opts += " $(%s)" % link_opts_command
 
         return docker_opts, env
 

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -88,6 +88,7 @@ def get_docker_run_gpu_cmd_prefix(need_gpu, service_type, service_name):
     if need_gpu:
         if common.no_gpu:
             common.logger.info("GPU needed by %s '%s' but DMAKE_NO_GPU set: trying without GPU." % (service_type, service_name))
+            prefix = 'DMAKE_DOCKER_RUN_WITH_GPU=none '
             pass
         else:
             common.need_gpu = True

--- a/dmake/utils/dmake_run_docker
+++ b/dmake/utils/dmake_run_docker
@@ -50,8 +50,9 @@ fi
 
 # support some GPU modes using nvidia docker v2
 DOCKER_RUN_ARGS=( run )
-if [[ "${DMAKE_DOCKER_RUN_WITH_GPU}" == "all" ]]; then
-  DOCKER_RUN_ARGS+=( --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all )
+if [[ "${DMAKE_DOCKER_RUN_WITH_GPU}" == 'yes' ]]; then
+  DEVICES=${DMAKE_GPU#GPU_}
+  DOCKER_RUN_ARGS+=( --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=${DEVICES:-all} )
 fi
 
 docker "${DOCKER_RUN_ARGS[@]}" --name ${NAME} "$@"

--- a/dmake/utils/dmake_run_docker
+++ b/dmake/utils/dmake_run_docker
@@ -53,6 +53,8 @@ DOCKER_RUN_ARGS=( run )
 if [[ "${DMAKE_DOCKER_RUN_WITH_GPU}" == 'yes' ]]; then
   DEVICES=${DMAKE_GPU#GPU_}
   DOCKER_RUN_ARGS+=( --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=${DEVICES:-all} )
+elif [[ "${DMAKE_DOCKER_RUN_WITH_GPU}" == 'none' ]]; then
+  DOCKER_RUN_ARGS+=( -e NVIDIA_VISIBLE_DEVICES=none )
 fi
 
 docker "${DOCKER_RUN_ARGS[@]}" --name ${NAME} "$@"

--- a/test/gpu/deploy/Dockerfile
+++ b/test/gpu/deploy/Dockerfile
@@ -1,0 +1,6 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+COPY deploy/ /app
+
+WORKDIR /app

--- a/test/gpu/deploy/test-nvidia-smi.sh
+++ b/test/gpu/deploy/test-nvidia-smi.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -xe
+
+if [[ ${NVIDIA_VISIBLE_DEVICES} == 'none' ]]; then
+  echo "GPU needed for this test but dmake was executed with DMAKE_NO_GPU set."
+  echo "Test GPU was really disabled in dmake"
+  test "${DMAKE_NO_GPU}" == '1' -o "${DMAKE_NO_GPU}" == 'true'
+  exit
+fi
+
+
+echo "Test nvidia-smi execution"
+nvidia-smi
+
+echo "Test at least one GPU is available"
+test $(nvidia-smi -L | wc -l) -ge 1

--- a/test/gpu/dmake.yml
+++ b/test/gpu/dmake.yml
@@ -1,0 +1,25 @@
+dmake_version: 0.1
+app_name: dmake-test
+
+env:
+  default:
+    variables:
+      DMAKE_NO_GPU: ${DMAKE_NO_GPU}
+
+docker:
+  root_image:
+    name: tensorflow/tensorflow
+    tag: 1.11.0-gpu
+
+services:
+  - service_name: test-gpu
+    config:
+      need_gpu: true
+      docker_image:
+        build:
+          context: .
+          dockerfile: ./deploy/Dockerfile
+    tests:
+      commands:
+        - /app/test-nvidia-smi.sh
+      timeout: 5


### PR DESCRIPTION
* Support multi GPUs on jenkins

Depends on lockable resources defined on Jenkins: one per GPU:
- name: GPU_0, label: GPUS
- name: GPU_1, label: GPUS

On local mode, give access to all GPUs, as before. Can now also be
overwritten using `DMAKE_GPU=x` environment variable.

* Add NVIDIA_VISIBLE_DEVICES=none when no GPU available

* Add test for GPUs

* Add README for GPUs