### PR TITLE
Fix yaml dump error on kubernetes with user configmap from files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ruamel.yaml==0.15.70
+ruamel.yaml==0.15.71
 kubernetes==4.0.0
 urllib3>=1.20
 backports.ssl-match-hostname>=3.5.0.1


### PR DESCRIPTION
There was a bug in upstream ruamel.yaml lib, fixed in 0.15.71.

See https://bitbucket.org/ruamel/yaml/issues/241/insufficient-indentation-with