### PR TITLE
Explain that Jenkins jobs rerun are not supported when it probably happened

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -787,6 +787,8 @@ def make(options):
     append_command(all_commands, 'env', var = "BUILD", value = common.build_id)
     append_command(all_commands, 'env', var = "BRANCH", value = common.branch)
     append_command(all_commands, 'env', var = "DMAKE_TMP_DIR", value = common.tmp_dir)
+    # check DMAKE_TMP_DIR still exists: detects unsupported jenkins reruns: clear error
+    append_command(all_commands, 'sh', shell = 'dmake_check_tmp_dir')
 
     for stage, commands in ordered_build_files:
         if len(commands) == 0:

--- a/dmake/utils/dmake_check_tmp_dir
+++ b/dmake/utils/dmake_check_tmp_dir
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Usage:
+# dmake_check_tmp_dir
+#
+# Result:
+# Raises a user readable error if tmp dir is not found
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -ne 0 ]; then
+    dmake_fail "$0: Missing arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    echo "exit 1"
+    exit 1
+fi
+
+set -e
+
+if [ ! -d "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "DMake temporary directory not found. Maybe you reran the Jenkins job? It is not supported. Build the job again instead."
+    echo "exit 1"
+    exit 1
+fi


### PR DESCRIPTION
Closes #286 

Jenkins (notably the blue ocean interface) proposes everywhere to
rerun the job. Alas it is *not* supported by DMake, because rerun
masks dynamically generated Jenkinsfiles which depend on dynamically
generated temporary directories, which are cleaned at the end of the
first run => rerun always fail, after some steps, with unhelpful
errors.

Now we start the pipeline by checking that the tmp dir exists, and
print a useful error message if not.