### PR TITLE
Add kubernetes.secrets deployment: create generic secrets from files

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -672,13 +672,50 @@ class K8SCDDeploySerializer(YAML2PipelineSerializer):
         cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
         append_command(commands, 'sh', shell = cmd)
 
-class KuberentesConfigMapFromFileSerializer(YAML2PipelineSerializer):
-    key = FieldSerializer("string", example = "nginx.conf", help_text = "File key")
-    path = FieldSerializer("file", example = "deploy/nginx.conf", help_text = "File path")
 
-class KuberentesConfigMapSerializer(YAML2PipelineSerializer):
+class KubernetesConfigMapFromFileSerializer(YAML2PipelineSerializer):
+    key = FieldSerializer("string", example = "nginx.conf", help_text = "File key")
+    path = FieldSerializer("file",  example = "deploy/nginx.conf", help_text = "File path (relative to this dmake.yml file)")
+
+    def get_arg(self):
+        arg = "--from-file=%s=%s" % (self.key, self.path)
+        return arg
+
+
+class KubernetesSecretFromFileSerializer(YAML2PipelineSerializer):
+    key = FieldSerializer("string", example = "ssh-privatekey", help_text = "File key")
+    path = FieldSerializer("string",  example = "${SECRETS}/ssh_id_rsa", help_text = "Absolute file path. Supports variables substitution.")
+
+    def get_arg(self, env):
+        path = common.eval_str_in_env(self.path, env)
+
+        if not os.path.isfile(path):
+            raise DMakeException("Invalid Kubernetes Secret 'from_files' absolute path: key '%s', path '%s' (expanded from '%s'): file not found" % (self.key, path, self.path))
+
+        arg = "--from-file=%s=%s" % (self.key, path)
+        return arg
+
+
+class KubernetesConfigMapSerializer(YAML2PipelineSerializer):
     name = FieldSerializer("string", example = "nginx", help_text = "Kubernetes ConfigMap name")
-    from_files = FieldSerializer("array", child = KuberentesConfigMapFromFileSerializer(), default = [], help_text = "Kubernetes ConfigMap from files")
+    from_files = FieldSerializer("array", child = KubernetesConfigMapFromFileSerializer(), default = [], help_text = "Kubernetes create values from files")
+
+    def generate_manifest(self, env):
+        from_file_args = [file_source.get_arg() for file_source in self.from_files]
+        return k8s_utils.generate_from_create(args=['configmap'], name=self.name, from_file_args=from_file_args)
+
+
+class KubernetesSecretGenericSerializer(YAML2PipelineSerializer):
+    from_files = FieldSerializer("array", child = KubernetesSecretFromFileSerializer(), default = [], help_text = "Kubernetes create values from files")
+
+
+class KubernetesSecretSerializer(YAML2PipelineSerializer):
+    name    = FieldSerializer("string", example = "ssh-key", help_text = "Kubernetes Secret name")
+    generic = FieldSerializer(KubernetesSecretGenericSerializer(), help_text = "Kubernetes Generic Secret type parameters")
+
+    def generate_manifest(self, env):
+        from_file_args = [file_source.get_arg(env) for file_source in self.generic.from_files]
+        return k8s_utils.generate_from_create(args=['secret', 'generic'], name=self.name, from_file_args=from_file_args)
 
 class KubernetesManifestSerializer(YAML2PipelineSerializer):
     template  = FieldSerializer("file", example = "path/to/kubernetes-manifest.yaml", help_text = "Kubernetes manifest file (template) defining all the resources needed to deploy the service")
@@ -705,7 +742,8 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
     context   = FieldSerializer("string", help_text = "kubectl context to use.")
     namespace = FieldSerializer("string", optional = True, help_text = "Kubernetes namespace to target (overrides kubectl context default namespace")
     manifest  = FieldSerializer(KubernetesManifestSerializer(), example = "path/to/kubernetes-manifest.yaml", help_text = "Kubernetes manifest file (template) defining all the resources needed to deploy the service")
-    config_maps = FieldSerializer("array", child = KuberentesConfigMapSerializer(), default = [], help_text = "Additional Kubernetes ConfigMaps")
+    config_maps = FieldSerializer("array", child = KubernetesConfigMapSerializer(), default = [], help_text = "Additional Kubernetes ConfigMaps")
+    secrets     = FieldSerializer("array", child = KubernetesSecretSerializer(), default = [], help_text = "Additional Kubernetes Secrets")
 
     def _serialize_(self, commands, app_name, image_name, env):
         if not self.has_value():
@@ -726,19 +764,19 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
         });
         configmap_name = k8s_utils.generate_config_map_file(env, app_name, os.path.join(tmp_dir, configmap_env_filename), labels = configmap_env_labels)
 
-        # additional ConfigMaps
+        # additional resources
+        def generate_and_write_additional_resources(sources, filename):
+            data = [source.generate_manifest(env=env) for source in sources]
+            # concat manifests
+            data_str = '%s\n' % ('\n\n---\n\n'.join(data))
+            # write manifests to file
+            with open(os.path.join(tmp_dir, filename), 'w') as f:
+                k8s_utils.dump_all_str_and_add_labels(data_str, f, dmake_generated_labels)
+
         user_configmaps_filename = 'kubernetes-user-configmaps.yaml'
-        cm_datas = []
-        for cm in self.config_maps:
-            program = 'kubectl'
-            from_file_args = ["--from-file=%s=%s" % (file_source.key, file_source.path) for file_source in cm.from_files]
-            args = ['create', 'configmap', '--dry-run=true', '--output=yaml', cm.name] + from_file_args
-            cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
-            cm_data = common.run_shell_command(cmd, raise_on_return_code=True)
-            cm_datas.append(cm_data)
-        cm_datas_str = '%s\n' % ('\n\n---\n\n'.join(cm_datas))
-        with open(os.path.join(tmp_dir, user_configmaps_filename), 'w') as f:
-            k8s_utils.dump_all_str_and_add_labels(cm_datas_str, f, dmake_generated_labels)
+        generate_and_write_additional_resources(self.config_maps, user_configmaps_filename)
+        user_secrets_filename = 'kubernetes-user-secrets.yaml'
+        generate_and_write_additional_resources(self.secrets, user_secrets_filename)
 
         # copy/render template manifest file
         user_manifest_filename = 'kubernetes-user-manifest.yaml'
@@ -775,7 +813,7 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
                 common.repo,
                 common.branch,
                 common.commit_id,
-                'no-pruning:%s' % (configmap_env_filename), user_configmaps_filename, user_manifest_filename]
+                'no-pruning:%s' % (configmap_env_filename), user_configmaps_filename, user_secrets_filename, user_manifest_filename]
         cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
         append_command(commands, 'sh', shell = cmd)
 

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -674,8 +674,8 @@ class K8SCDDeploySerializer(YAML2PipelineSerializer):
 
 
 class KubernetesConfigMapFromFileSerializer(YAML2PipelineSerializer):
-    key = FieldSerializer("string", example = "nginx.conf", help_text = "File key")
-    path = FieldSerializer("file",  example = "deploy/nginx.conf", help_text = "File path (relative to this dmake.yml file)")
+    key  = FieldSerializer("string", example="nginx.conf", help_text="File key")
+    path = FieldSerializer("file",  example="deploy/nginx.conf", help_text="File path (relative to this dmake.yml file)")
 
     def get_arg(self):
         arg = "--from-file=%s=%s" % (self.key, self.path)
@@ -683,8 +683,8 @@ class KubernetesConfigMapFromFileSerializer(YAML2PipelineSerializer):
 
 
 class KubernetesSecretFromFileSerializer(YAML2PipelineSerializer):
-    key = FieldSerializer("string", example = "ssh-privatekey", help_text = "File key")
-    path = FieldSerializer("string",  example = "${SECRETS}/ssh_id_rsa", help_text = "Absolute file path. Supports variables substitution.")
+    key  = FieldSerializer("string", example="ssh-privatekey", help_text="File key")
+    path = FieldSerializer("string",  example="${SECRETS}/ssh_id_rsa", help_text="Absolute file path. Supports variables substitution.")
 
     def get_arg(self, env):
         path = common.eval_str_in_env(self.path, env)
@@ -697,8 +697,8 @@ class KubernetesSecretFromFileSerializer(YAML2PipelineSerializer):
 
 
 class KubernetesConfigMapSerializer(YAML2PipelineSerializer):
-    name = FieldSerializer("string", example = "nginx", help_text = "Kubernetes ConfigMap name")
-    from_files = FieldSerializer("array", child = KubernetesConfigMapFromFileSerializer(), default = [], help_text = "Kubernetes create values from files")
+    name       = FieldSerializer("string", example="nginx", help_text="Kubernetes ConfigMap name")
+    from_files = FieldSerializer("array", child=KubernetesConfigMapFromFileSerializer(), default=[], help_text="Kubernetes create values from files")
 
     def generate_manifest(self, env):
         from_file_args = [file_source.get_arg() for file_source in self.from_files]
@@ -706,19 +706,19 @@ class KubernetesConfigMapSerializer(YAML2PipelineSerializer):
 
 
 class KubernetesSecretGenericSerializer(YAML2PipelineSerializer):
-    from_files = FieldSerializer("array", child = KubernetesSecretFromFileSerializer(), default = [], help_text = "Kubernetes create values from files")
+    from_files = FieldSerializer("array", child=KubernetesSecretFromFileSerializer(), default=[], help_text="Kubernetes create values from files")
 
 
 class KubernetesSecretSerializer(YAML2PipelineSerializer):
-    name    = FieldSerializer("string", example = "ssh-key", help_text = "Kubernetes Secret name")
-    generic = FieldSerializer(KubernetesSecretGenericSerializer(), help_text = "Kubernetes Generic Secret type parameters")
+    name    = FieldSerializer("string", example="ssh-key", help_text="Kubernetes Secret name")
+    generic = FieldSerializer(KubernetesSecretGenericSerializer(), help_text="Kubernetes Generic Secret type parameters")
 
     def generate_manifest(self, env):
         from_file_args = [file_source.get_arg(env) for file_source in self.generic.from_files]
         return k8s_utils.generate_from_create(args=['secret', 'generic'], name=self.name, from_file_args=from_file_args)
 
 class KubernetesManifestSerializer(YAML2PipelineSerializer):
-    template  = FieldSerializer("file", example = "path/to/kubernetes-manifest.yaml", help_text = "Kubernetes manifest file (template) defining all the resources needed to deploy the service")
+    template  = FieldSerializer("file", example="path/to/kubernetes-manifest.yaml", help_text="Kubernetes manifest file (template) defining all the resources needed to deploy the service")
     variables = FieldSerializer('dict', child="string", default={}, help_text="Defines variables used in the kubernetes manifest template", example={'TLS_SECRET_NAME': '${K8S_DEPLOY_TLS_SECRET_NAME}'})
 
     def _validate_(self, file, needed_migrations, data, field_name):
@@ -739,11 +739,11 @@ class KubernetesManifestSerializer(YAML2PipelineSerializer):
 
 
 class KubernetesDeploySerializer(YAML2PipelineSerializer):
-    context   = FieldSerializer("string", help_text = "kubectl context to use.")
-    namespace = FieldSerializer("string", optional = True, help_text = "Kubernetes namespace to target (overrides kubectl context default namespace")
-    manifest  = FieldSerializer(KubernetesManifestSerializer(), optional = True, help_text = "Kubernetes manifest (file template) defining all the resources needed to deploy the service")
-    config_maps = FieldSerializer("array", child = KubernetesConfigMapSerializer(), default = [], help_text = "Additional Kubernetes ConfigMaps")
-    secrets     = FieldSerializer("array", child = KubernetesSecretSerializer(), default = [], help_text = "Additional Kubernetes Secrets")
+    context     = FieldSerializer("string", help_text="kubectl context to use.")
+    namespace   = FieldSerializer("string", optional=True, help_text="Kubernetes namespace to target (overrides kubectl context default namespace")
+    manifest    = FieldSerializer(KubernetesManifestSerializer(), optional=True, help_text="Kubernetes manifest (file template) defining all the resources needed to deploy the service")
+    config_maps = FieldSerializer("array", child=KubernetesConfigMapSerializer(), default=[], help_text="Additional Kubernetes ConfigMaps")
+    secrets     = FieldSerializer("array", child=KubernetesSecretSerializer(), default=[], help_text="Additional Kubernetes Secrets")
 
     def _serialize_(self, commands, app_name, image_name, env):
         if not self.has_value():

--- a/dmake/kubernetes.py
+++ b/dmake/kubernetes.py
@@ -4,11 +4,13 @@ import yaml
 
 import dmake.common as common
 
+
 def get_env_hash(env):
     """Return a stable hash for the `env` environment."""
     serialized_env = json.dumps(sorted(env.items()))
     serialized_env_binary = common.to_string(serialized_env).encode('UTF-8')
     return hashlib.sha256(serialized_env_binary).hexdigest()[:10]
+
 
 def generate_config_map(env, name, labels = None):
     """Return a kubernetes manifest defining a ConfigMap storing `env`."""
@@ -26,6 +28,7 @@ data: {}
     data['data'] = env
     return data
 
+
 def generate_config_map_file(env, name_prefix, output_filepath, labels = None):
     """Generate a ConfigMap manifest file with unique env-hashed name, and return the name."""
     env_hash = get_env_hash(env)
@@ -35,13 +38,23 @@ def generate_config_map_file(env, name_prefix, output_filepath, labels = None):
         yaml.dump(data, configmap_file, default_flow_style=False)
     return name
 
+
 def add_labels(resource, labels):
     if 'labels' not in resource['metadata']:
         resource['metadata']['labels'] = {}
     resource['metadata']['labels'].update(labels)
+
 
 def dump_all_str_and_add_labels(data_str, file, labels):
     data = common.yaml_ordered_load(data_str, all=True)
     for resource in data:
         add_labels(resource, labels)
     common.yaml_ordered_dump(data, file, all=True)
+
+
+def generate_from_create(args, name, from_file_args):
+    program = 'kubectl'
+    args = ['create'] + args + ['--dry-run=true', '--output=yaml', name] + from_file_args
+    cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
+    manifest = common.run_shell_command(cmd, raise_on_return_code=True)
+    return manifest


### PR DESCRIPTION
Closes #291 

Accept absolute path with variable substitution.

It differs from kubernetes.config_maps which accepts path relative to
the dmake.yml file, without variable substitution.

Example:
```yaml
env:
  default:
    source: ${CONFIG_DIR}/dev.sh
    variables:
      SECRETS_PATH: ${SECRETS_PATH}
....
          kubernetes:
            secrets:
              - name: my-secret
                generic:
                  from_files:
                    - key: ssh-privatekey
                      path: ${CONFIG_DIR}/${SECRETS_PATH}/ssh/id_rsa
                    - key: ssh-publickey
                      path: ${CONFIG_DIR}/${SECRETS_PATH}/ssh/id_rsa.pub
```

Also fixed typo: kuberentes -> kubernetes