### PR TITLE
Add `env_override` in `services[].config`: extra env per service

### DIFF
--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -7,6 +7,7 @@ env:
       AMQP_URL: amqp://rabbitmq/dev
       SHARED_VOLUME_ROOT: /shared_volume_root_value
       ENV_EVALUATION_TEST: foobar
+      ENV_OVERRIDE_TEST: 1
   branches:
     master:
       variables:
@@ -35,6 +36,9 @@ services:
       - service_name: test-worker:ubuntu-1604
         env:
           TEST_SHARED_VOLUME: 1
+          TEST_ENV_OVERRIDE: 1
+          ENV_OVERRIDE_TEST3: from_needed_service_env
+          ENV_OVERRIDE_TEST5: from_needed_service_env
       - service_name: test-worker:ubuntu-1804
         link_name: worker-ubuntu-1804
         env:
@@ -61,6 +65,8 @@ services:
     tests:
       commands:
         - test "${ENV_EVALUATION_TEST}" = 'foobar' # test environment evaluation: should be evaluated in container
+        - test "${ENV_OVERRIDE_TEST}" = '1' # test env override: should use the root `env` value
+        - test -z "${ENV_OVERRIDE_TEST2+x}" # test env override 2: should not be set
         - touch 'tag' # test shared environment for multiple commands test
         - test -f "tag"  # test command escaping
         - deploy/test-shared-volumes.sh /shared_volume_root_value/shared_volume_with_workers
@@ -85,6 +91,9 @@ services:
       docker_image:
         entrypoint: deploy/entrypoint.sh
         start_script: deploy/start.sh
+      env_override:
+        ENV_OVERRIDE_TEST: 2
+        ENV_OVERRIDE_TEST2: 3
       ports:
         - container_port: 8000
           # no host_port: always random port
@@ -97,3 +106,7 @@ services:
           - /dev/null
         period_seconds: 1
         max_seconds: 10
+    tests:
+      commands:
+        - test "${ENV_OVERRIDE_TEST}" = '2'  # test env override: should use the `env_override` value override
+        - test "${ENV_OVERRIDE_TEST2}" = '3' # test env override 2: should use the `env_override` value only definition

--- a/test/worker/deploy/start.sh
+++ b/test/worker/deploy/start.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
+set -e
+
 if [ "${TEST_SHARED_VOLUME}" -eq 1 ]; then
   echo "Write file for volume test"
   echo "hello from worker: ${HOSTNAME}" >> /shared_volume/hello-from-worker.${HOSTNAME}
 fi
+
+if [ "${TEST_ENV_OVERRIDE}" -eq 1 ]; then
+  echo "Test env override"
+  test "${ENV_OVERRIDE_TEST1}" = from_root_env
+  test "${ENV_OVERRIDE_TEST2}" = from_env_override
+  test "${ENV_OVERRIDE_TEST3}" = from_needed_service_env
+  test "${ENV_OVERRIDE_TEST4}" = from_env_override
+  test "${ENV_OVERRIDE_TEST5}" = from_needed_service_env
+fi
+
 
 exec ./bin/worker

--- a/test/worker/dmake.yml
+++ b/test/worker/dmake.yml
@@ -17,6 +17,9 @@ env:
   default:
     variables:
       AMQP_URL: amqp://rabbitmq/dev
+      ENV_OVERRIDE_TEST1: from_root_env
+      ENV_OVERRIDE_TEST2: from_root_env
+      ENV_OVERRIDE_TEST3: from_root_env
   branches:
     master:
       variables:
@@ -57,11 +60,21 @@ services:
             com.deepomatic.version.is-on-premises: "false"
             build-host: "${HOSTNAME}"
           target: runtime
+      env_override:
+        ENV_OVERRIDE_TEST2: from_env_override
+        ENV_OVERRIDE_TEST3: from_env_override
+        ENV_OVERRIDE_TEST4: from_env_override
       volumes:
         - source: shared_rabbitmq_var_lib
           target: /var/lib/rabbitmq
         - shared_volume_web_and_workers:/shared_volume
     tests:
       commands:
+        # test env override
+        - test "${ENV_OVERRIDE_TEST1}" = from_root_env
+        - test "${ENV_OVERRIDE_TEST2}" = from_env_override
+        - test "${ENV_OVERRIDE_TEST3}" = from_env_override
+        - test "${ENV_OVERRIDE_TEST4}" = from_env_override
+        - test -z "${ENV_OVERRIDE_TEST5+x}" # should not be set (defined in needed_service.env that should not apply to service test
         - ./deploy/test-shared-volumes.sh
         - ./bin/worker_test


### PR DESCRIPTION
Closes #159 

Before that we could only define environment variables for all the
services in the dmake.yml file via the root `.env`.

Each service now uses env from root `.env` completed by service
`config.env_override`.

In case of `needed_services[].env`, the started service now uses env
from root `.env` completed by service `config.env_override` completed
by needed_service `.env`.

Each env layer has its values evaluated from the previous layers
resulting env.

Variables in the yaml at the service level are evaluated from the
fully resolved env for the service (root `.env` + service
`config.env_override`).
