### PR TITLE
Expose DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP on jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,9 @@ properties([
         booleanParam(name: 'DMAKE_DEBUG',
                      defaultValue: true,
                      description: 'Enable dmake debug logs'),
+        booleanParam(name: 'DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP',
+                     defaultValue: true,
+                     description: 'Ask user confirmation before DMake cleanup.'),
         booleanParam(name: 'DMAKE_FORCE_BASE_IMAGE_BUILD',
                      defaultValue: false,
                      description: 'Force base image build (don\'t use base image cache)'),
@@ -62,11 +65,13 @@ node {
     env.CHANGE_BRANCH=""
     env.CHANGE_TARGET=""
     env.CHANGE_ID=""
-    env.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP=1
     // params are automatically exposed as environment variables
     // but booleans to string generates "true"
     if (params.DMAKE_DEBUG) {
         env.DMAKE_DEBUG=1
+    }
+    if (params.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP) {
+        env.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP=1
     }
   }
   stage('Python 2.x') {

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -17,6 +17,14 @@ try {
     default_dmake_debug=false
 }
 
+
+try {
+    default_dmake_pause_on_error_before_cleanup=DEFAULT_PAUSE_ON_ERROR_BEFORE_CLEANUP
+} catch (e) {
+    default_dmake_pause_on_error_before_cleanup=false
+}
+
+
 try {
     default_dmake_force_base_image_build=DEFAULT_DMAKE_FORCE_BASE_IMAGE_BUILD
 } catch (e) {
@@ -40,6 +48,9 @@ properties([
         booleanParam(name: 'DMAKE_DEBUG',
                      defaultValue: default_dmake_debug,
                      description: 'Enable dmake debug logs'),
+        booleanParam(name: 'DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP',
+                     defaultValue: default_dmake_pause_on_error_before_cleanup,
+                     description: 'Ask user confirmation before DMake cleanup.'),
         booleanParam(name: 'DMAKE_FORCE_BASE_IMAGE_BUILD',
                      defaultValue: default_dmake_force_base_image_build,
                      description: 'Force base image build (don\'t use base image cache)'),
@@ -60,6 +71,9 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
     // but booleans to string generates "true"
     if (params.DMAKE_DEBUG) {
         env.DMAKE_DEBUG=1
+    }
+    if (params.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP) {
+        env.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP=1
     }
     sh "${params.CUSTOM_ENVIRONMENT} dmake deploy '${params.DMAKE_APP}'"
     load 'DMakefile'


### PR DESCRIPTION
Closes #294

Useful when debugging to check container state, logs, content before
DMake cleanup.