### PR TITLE
Add `dmake build` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,14 @@ $ dmake shell -d worker
 ```
 There you can build an execute your service, and quickly iterate by editting the code from your favorite editor.
 
+### `dmake build`
+If you want to build a service and its dependencies (optional).
+
+```
+$ dmake build -d worker
+```
+You can now execute your service to see if everything works as expected.
+
 ### `dmake run`
 You can now run the full app with:
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ There are much more features in DMake (deployment on kubernetes, multiple varian
 
 
 ### `dmake` command-line interface
+The command-line interface is based on this template: `dmake <command> <service>`
+
+For most commands, `<service>` can also be `*` to target all services.
 
 #### `dmake test`
 Now that we went through the configuration file, you can try to test the worker with:
@@ -160,7 +163,7 @@ $ dmake test -d worker
 
 The `-d` option tells **DMake** to run all the dependencies of the service as well.
 
-### `dmake shell`
+#### `dmake shell`
 To interactively work on a service, dmake provides a shell access in the service container (running the base image), with the sources mounted into it:
 
 ```
@@ -168,15 +171,7 @@ $ dmake shell -d worker
 ```
 There you can build an execute your service, and quickly iterate by editting the code from your favorite editor.
 
-### `dmake build`
-If you want to build a service and its dependencies (optional).
-
-```
-$ dmake build -d worker
-```
-You can now execute your service to see if everything works as expected:
-
-### `dmake run`
+#### `dmake run`
 You can now run the full app with:
 
 ```
@@ -191,6 +186,15 @@ By the way, when there are multiple application in the same repository and multi
 ```
 $ dmake run -d dmake-tutorial/web
 ```
+
+#### `dmake build`
+To just build a service (or all services), without running them, use `dmake build`:
+
+```
+$ dmake build worker
+$ dmake build '*'
+```
+
 
 ## Using GPUs
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you want to build a service and its dependencies (optional).
 ```
 $ dmake build -d worker
 ```
-You can now execute your service to see if everything works as expected.
+You can now execute your service to see if everything works as expected:
 
 ### `dmake run`
 You can now run the full app with:

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -244,6 +244,9 @@ def init(_options):
     options = _options
     command = _options.cmd
 
+    if command == 'build':
+        command = 'build_docker'
+
     generate_dot_graph = options.debug_graph or options.debug_graph_and_exit
     exit_after_generate_dot_graph = options.debug_graph_and_exit
     dot_graph_filename = options.debug_graph_output_filename

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -115,7 +115,7 @@ def add_service_provider(service_providers, service, file, needs = None, base_va
 
 def activate_file(loaded_files, service_providers, service_dependencies, command, file):
     dmake_file = loaded_files[file]
-    if command in ['test', 'run', 'deploy']:
+    if command in ['test', 'run', 'deploy', 'build_docker']:
         nodes = []
         for service in dmake_file.get_services():
             full_service_name = "%s/%s" % (dmake_file.app_name, service.service_name)

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -43,7 +43,7 @@ subparsers = argparser.add_subparsers(dest='cmd')
 subparsers.required = True
 
 parser_test    = subparsers.add_parser('test', help="Launch tests for the whole repo or, if specified, an app or one of its services.")
-parser_build   = subparsers.add_parser('build_docker', help="Launch the build for the whole repo or, if specified, an app or one of its services.")
+parser_build   = subparsers.add_parser('build', help="Launch the build for the whole repo or, if specified, an app or one of its services.")
 parser_run     = subparsers.add_parser('run', help="Launch the application or only one of its services.")
 parser_stop    = subparsers.add_parser('stop', help="Stop the containers lauched with 'dmake run'.")
 parser_shell   = subparsers.add_parser('shell', help="Run a shell session withing a docker container with the environment set up for a given service.")

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -43,6 +43,7 @@ subparsers = argparser.add_subparsers(dest='cmd')
 subparsers.required = True
 
 parser_test    = subparsers.add_parser('test', help="Launch tests for the whole repo or, if specified, an app or one of its services.")
+parser_build   = subparsers.add_parser('build_docker', help="Launch the build for the whole repo or, if specified, an app or one of its services.")
 parser_run     = subparsers.add_parser('run', help="Launch the application or only one of its services.")
 parser_stop    = subparsers.add_parser('stop', help="Stop the containers lauched with 'dmake run'.")
 parser_shell   = subparsers.add_parser('shell', help="Run a shell session withing a docker container with the environment set up for a given service.")
@@ -53,6 +54,7 @@ parser_release = subparsers.add_parser('release', help="Create a release of the 
 add_argument([parser_test, parser_deploy], "service", nargs='?', default='*', help="Apply command to the full repository or, if specified, to the app/service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.")
 add_argument([parser_shell],               "service", nargs='?', default='.', help="Run a shell session withing the docker base image for the given service. You may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.")
 add_argument([parser_run],                 "service", help="Run an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.")
+add_argument([parser_build],               "service", help="Build an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.")
 
 parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specified command instead of `docker.command` defined in `dmake.yml` (default: `bash`).")
 add_argument([parser_shell, parser_run, parser_test], "-d", "--dependencies", required=False, default=False, action="store_true", help="By default, the service is launched as a standalone. If this flag is specified, the dependancies of the service and links specified in the test config as run as well.")
@@ -63,6 +65,7 @@ parser_release.add_argument('-t', '--tag', nargs='?', help="The release tag from
 
 parser_test.set_defaults(func=core.make)
 parser_run.set_defaults(func=core.make)
+parser_build.set_defaults(func=core.make)
 parser_stop.set_defaults(func=commands.stop.entry_point)
 parser_shell.set_defaults(func=core.make)
 parser_deploy.set_defaults(func=commands.deploy.entry_point)


### PR DESCRIPTION
Closes #171

Add dmake command to just build services docker images.

Examples:
- `dmake build worker`
- `dmake build '*'`