### PR TITLE
Fix dmake_deploy_kubernetes for MacOS

### DIFF
--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -43,7 +43,7 @@ function echo_title() {
   echo [DMake] "$@"
 }
 
-deploy_timestamp=$(date --iso-8601=seconds)
+deploy_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 echo_title Apply ${SERVICE} to kubernetes cluster ${CONTEXT}:
 


### PR DESCRIPTION
Their `date` doesn't support `--iso-8601`.