### PR TITLE
Fixed version sorting in dmake release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ $ dmake build worker
 $ dmake build '*'
 ```
 
+#### `dmake release` (experimental)
+
+Allow to create a github release from a git tag, with a generated changelog:
+
+```
+# Makes sure you are on the branch you want to release and up to date
+SEMVER_TAG=1.0.0  # put your release tag here
+$ git tag $SEMVER_TAG
+$ git push origin $SEMVER_TAG
+dmake release -t $SEMVER_TAG myapp
+```
 
 ## Using GPUs
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Allow to create a github release from a git tag, with a generated changelog:
 
 ```
 # Makes sure you are on the branch you want to release and up to date
+DMAKE_GITHUB_TOKEN=MyGithubAccessToken # https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+DMAKE_GITHUB_OWNER=MyAccount # account or organization owning the repository
 SEMVER_TAG=1.0.0  # put your release tag here
 $ git tag $SEMVER_TAG
 $ git push origin $SEMVER_TAG

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ In order to run **DMake**, you will need:
 
 In order to install **DMake**, use the following:
 
-```
-$ git clone https://github.com/Deepomatic/dmake.git
-$ cd dmake
-$ ./install.sh
+```sh
+git clone https://github.com/Deepomatic/dmake.git
+cd dmake
+./install.sh
 ```
 
 After following the instructions, check that **DMake** is found by running:
 
-```
-$ dmake --help
+```sh
+dmake --help
 ```
 
 It should display the help message with the list of commands.
@@ -34,22 +34,22 @@ It should display the help message with the list of commands.
 
 To start the tutorial, enter the tutorial directory:
 
-```
-$ cd tutorial
+```sh
+cd tutorial
 ```
 
 For those who just want to see the results, just run:
 
-```
-$ dmake run -d web
+```sh
+dmake run -d web
 ```
 
 Once it has completed, the factorial demo is available at [http://localhost:8000](http://localhost:8000)
 
 Before moving to the details, do not forget to shutdown the launched containers with:
 
-```
-$ dmake stop
+```sh
+dmake stop
 ```
 
 Alright ! To simulate an application made of several micro-services, this project is made of two services:
@@ -157,8 +157,8 @@ For most commands, `<service>` can also be `*` to target all services.
 #### `dmake test`
 Now that we went through the configuration file, you can try to test the worker with:
 
-```
-$ dmake test -d worker
+```sh
+dmake test -d worker
 ```
 
 The `-d` option tells **DMake** to run all the dependencies of the service as well.
@@ -166,16 +166,16 @@ The `-d` option tells **DMake** to run all the dependencies of the service as we
 #### `dmake shell`
 To interactively work on a service, dmake provides a shell access in the service container (running the base image), with the sources mounted into it:
 
-```
-$ dmake shell -d worker
+```sh
+dmake shell -d worker
 ```
 There you can build an execute your service, and quickly iterate by editting the code from your favorite editor.
 
 #### `dmake run`
 You can now run the full app with:
 
-```
-$ dmake run -d web
+```sh
+dmake run -d web
 ```
 It will start the `web` service with all its dependencies (RabbitMQ and the worker).
 
@@ -183,30 +183,56 @@ Once it has completed, the factorial demo is available at [http://localhost:8000
 
 By the way, when there are multiple application in the same repository and multiple services with the same name, you must specify the full service name like this:
 
-```
-$ dmake run -d dmake-tutorial/web
+```sh
+dmake run -d dmake-tutorial/web
 ```
 
 #### `dmake build`
 To just build a service (or all services), without running them, use `dmake build`:
 
-```
-$ dmake build worker
-$ dmake build '*'
+```sh
+dmake build worker
+dmake build '*'
 ```
 
 #### `dmake release` (experimental)
 
-Allow to create a github release from a git tag, with a generated changelog:
+Create a github release from a manually previously created git tag. DMake will also generate a changelog.
+
+Make sure you are on the branch you want to release and up to date, for example:
+
+```sh
+git checkout master
+git pull origin master
+```
+
+Set some dmake env variables to access github. Feel free to add them in your `~/.bashrc` if you want them to be permanent:
+
+```sh
+export DMAKE_GITHUB_TOKEN=MyGithubAccessToken # https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+export DMAKE_GITHUB_OWNER=MyAccount # account or organization owning the repository
+```
+
+You can now create your release:
+
+```sh
+SEMVER_TAG=1.0.0  # put your release tag here
+git tag $[SEMVER_TAG}
+git push origin ${SEMVER_TAG}
+dmake release -t ${SEMVER_TAG} myapp
+```
+
+Should output:
 
 ```
-# Makes sure you are on the branch you want to release and up to date
-$ DMAKE_GITHUB_TOKEN=MyGithubAccessToken # https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
-$ DMAKE_GITHUB_OWNER=MyAccount # account or organization owning the repository
-$ SEMVER_TAG=1.0.0  # put your release tag here
-$ git tag $SEMVER_TAG
-$ git push origin $SEMVER_TAG
-$ dmake release -t $SEMVER_TAG myapp
+===============
+REPO : myapp
+BUILD : 0
+BRANCH : master
+COMMIT_ID : 123b123
+===============
+
+Done ! Check it at: https://github.com/MyAccount/myapp/releases/tag/1.0.0
 ```
 
 ## Using GPUs
@@ -217,12 +243,12 @@ Add `need_gpu: true` at the `service` `config` (or `docker_link`).
 It will run the service container with `docker run --runtime=nvidia`, using [NVIDIA docker 2](https://github.com/NVIDIA/nvidia-docker).
 
 By default it gives access to all GPUs available on the machine. You can restrict which GPU is used:
-```
-$ export DMAKE_GPU=2
+```sh
+export DMAKE_GPU=2
 # or
-$ nvidia-smi -L
+nvidia-smi -L
 GPU 0: GeForce GTX 1060 6GB (UUID: GPU-dfd9ebe0-1b0a-4cf9-a9c3-9edcd6a3449c)
-$ export DMAKE_GPU=GPU-dfd9ebe0-1b0a-4cf9-a9c3-9edcd6a3449c
+export DMAKE_GPU=GPU-dfd9ebe0-1b0a-4cf9-a9c3-9edcd6a3449c
 ```
 
 ## Using DMake with Jenkins
@@ -231,7 +257,7 @@ DMake can generate a `Jenkinsfile` instead of a `bash` file, allowing to execute
 
 Quickstart:
 - Configure Jenkins node:
-```
+```sh
 export DMAKE_ON_BUILD_SERVER=1`
 export DMAKE_PATH=/dmake
 export DMAKE_JENKINS_FILE=$DMAKE_PATH/dmake/templates/jenkins/Jenkinsfile

--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ Allow to create a github release from a git tag, with a generated changelog:
 
 ```
 # Makes sure you are on the branch you want to release and up to date
-DMAKE_GITHUB_TOKEN=MyGithubAccessToken # https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
-DMAKE_GITHUB_OWNER=MyAccount # account or organization owning the repository
-SEMVER_TAG=1.0.0  # put your release tag here
+$ DMAKE_GITHUB_TOKEN=MyGithubAccessToken # https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+$ DMAKE_GITHUB_OWNER=MyAccount # account or organization owning the repository
+$ SEMVER_TAG=1.0.0  # put your release tag here
 $ git tag $SEMVER_TAG
 $ git push origin $SEMVER_TAG
-dmake release -t $SEMVER_TAG myapp
+$ dmake release -t $SEMVER_TAG myapp
 ```
 
 ## Using GPUs

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ dmake build '*'
 
 Create a github release from a manually previously created git tag. DMake will also generate a changelog.
 
-Make sure you are on the branch you want to release and up to date, for example:
+Make sure you are on the branch you want to release and you are up to date, for example:
 
 ```sh
 git checkout master

--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -40,7 +40,7 @@ def entry_point(options):
         key = tag_to_key(tag.name)
         if key is not None:
             tags_list[key] = tag
-    sorted_release_keys = sorted(tags_list.keys(), key=lambda x: x, reverse=True)
+    sorted_release_keys = sorted(tags_list.keys(), reverse=True)
     latest_per_major_minor = {}
     for key in sorted_release_keys:
         if (key.major, key.minor) not in latest_per_major_minor:
@@ -51,16 +51,16 @@ def entry_point(options):
         questions = [
             inquirer.List(
                 'release_tag',
-                message="Which tag do you want to release?",
-                choices=[tags_list[key].name for key in sorted_release_keys if (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[(key.major, key.minor)] == key] + ['Other'],
+                message="Here are only the latest tags per minor version. Which tag do you want to release?",
+                choices=[tags_list[key].name for key in sorted_release_keys if (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[(key.major, key.minor)] == key] + ['All'],
             ),
         ]
         answers = inquirer.prompt(questions)
-        if answers['release_tag'] == 'Other':
+        if answers['release_tag'] == 'All':
             questions = [
                 inquirer.List(
                     'release_tag',
-                    message="Which tag do you want to release?",
+                    message="Here are all tags. Which tag do you want to release?",
                     choices=[tags_list[key].name for key in sorted_release_keys],
                     carousel=True
                 ),

--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -51,16 +51,16 @@ def entry_point(options):
         questions = [
             inquirer.List(
                 'release_tag',
-                message="Here are only the latest tags per minor version. Which tag do you want to release?",
-                choices=[tags_list[key].name for key in sorted_release_keys if (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[(key.major, key.minor)] == key] + ['All'],
+                message="Here are only the latest tags per major-minor version. Which tag do you want to release?",
+                choices=[tags_list[key].name for key in sorted_release_keys if (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[(key.major, key.minor)] == key] + ['Other'],
             ),
         ]
         answers = inquirer.prompt(questions)
-        if answers['release_tag'] == 'All':
+        if answers['release_tag'] == 'Other':
             questions = [
                 inquirer.List(
                     'release_tag',
-                    message="Here are all tags. Which tag do you want to release?",
+                    message="Here are all the tags. Which tag do you want to release?",
                     choices=[tags_list[key].name for key in sorted_release_keys],
                     carousel=True
                 ),

--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -40,7 +40,7 @@ def entry_point(options):
         key = tag_to_key(tag.name)
         if key is not None:
             tags_list[key] = tag
-    sorted_release_keys = sorted(tags_list.keys(), key=lambda x: x[1], reverse=True)
+    sorted_release_keys = sorted(tags_list.keys(), key=lambda x: x, reverse=True)
     latest_per_major_minor = {}
     for key in sorted_release_keys:
         if (key.major, key.minor) not in latest_per_major_minor:
@@ -51,7 +51,7 @@ def entry_point(options):
         questions = [
             inquirer.List(
                 'release_tag',
-                message="Which was the previously released version?",
+                message="Which tag do you want to release?",
                 choices=[tags_list[key].name for key in sorted_release_keys if (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[(key.major, key.minor)] == key] + ['Other'],
             ),
         ]
@@ -60,7 +60,7 @@ def entry_point(options):
             questions = [
                 inquirer.List(
                     'release_tag',
-                    message="Which was the previously released version?",
+                    message="Which tag do you want to release?",
                     choices=[tags_list[key].name for key in sorted_release_keys],
                     carousel=True
                 ),


### PR DESCRIPTION
- Semver tags were not well sorted (only by minor version for some reason) and this was causing troubles for the next part of the code which was depending on this.
`semver.VersionInfo` already support comparison operators. 

- Fixed question message which was not clear
- Updated readme