### PR TITLE
Use official registry URL

### DIFF
--- a/dmake/docker_config.py
+++ b/dmake/docker_config.py
@@ -56,6 +56,9 @@ def get_docker_config_auth(registry_url, dockercfg = '~/.docker/config.json'):
         if registry.startswith(registry_url):
             return credentials_store, registry, registry_data
     else:
+        if registry_url == 'https://registry-1.docker.io':
+            # fallback to default v1 creds
+            return get_docker_config_auth('https://index.docker.io', dockercfg)
         raise DMakeException('Auth not found for registry %s in docker config file %s' % (registry_url, dockercfg))
 
 

--- a/dmake/docker_registry.py
+++ b/dmake/docker_registry.py
@@ -9,7 +9,7 @@ from dmake.common import DMakeException, to_string, lru_cache, logger
 import dmake.docker_config as docker_config
 
 
-REGISTRY_URL = 'https://index.docker.io'
+REGISTRY_URL = 'https://registry-1.docker.io'
 
 
 def create_authenticated_requests_session(registry_url, token_url, scope, service):

--- a/dmake/docker_registry.py
+++ b/dmake/docker_registry.py
@@ -88,7 +88,7 @@ def get_image_digest(image):
 
     # https://docs.docker.com/registry/spec/api/#content-digests
     if response.status_code != 200 or 'Docker-Content-Digest' not in response.headers:
-        raise DMakeException('Docker registry: Error getting image digest: %s %s' % (response.status_code, response.text))
+        raise DMakeException('Docker registry: Error getting image digest: %s%s %s %s' % (REGISTRY_URL, manifest_path, response.status_code, response.text))
 
     return response.headers['Docker-Content-Digest']
 


### PR DESCRIPTION
`index.docker.io` was the original URL (registry v1). Since v2 the
official registry URL is `registry-1.docker.io`:
https://github.com/moby/moby/blob/a3f626d1019bd049dcc46ac8f64fe08b057e89f9/registry/config.go#L49-L52

And for retro-compatibility the client config.json file auth section
still uses `https://index.docker.io/v1/` as key.

Also raise a more complete exception when the registry returns 404.