### PR TITLE
Add cache for getting docker registry authenticated session

### DIFF
--- a/dmake/docker_registry.py
+++ b/dmake/docker_registry.py
@@ -12,6 +12,7 @@ import dmake.docker_config as docker_config
 REGISTRY_URL = 'https://registry-1.docker.io'
 
 
+@lru_cache()
 def create_authenticated_requests_session(registry_url, token_url, scope, service):
     """Performs docker registry authentication.
 


### PR DESCRIPTION
It is not strictly correct as the authenticated session has an
expiration date (on the official docker hub it is valid for 600s).
In such case the `TokenExpiredError` is raised.

We assume it won't happen: dmake execution should be much faster than
that. If it breaks in practice, we will have to implement our own
cache which checks the expiration date.

Test on dmake itself:
- before: 3.953s
- after:  3.088s