### PR TITLE
Allow relative host path in data_volumes for artifact creation during dmake test.

### DIFF
--- a/test/e2e/.dockerignore
+++ b/test/e2e/.dockerignore
@@ -1,3 +1,4 @@
 .dockerignore
 dmake.yml
 deploy/Dockerfile
+artifacts/

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/test/e2e/dmake.yml
+++ b/test/e2e/dmake.yml
@@ -6,6 +6,7 @@ env:
     variables:
       REPO: ${REPO}
       REPO_SANITIZED: ${REPO_SANITIZED}
+      COMMIT_ID: ${COMMIT_ID}
 
 docker:
   root_image:
@@ -25,8 +26,15 @@ services:
           context: .
           dockerfile: ./deploy/Dockerfile
     tests:
+      data_volumes:
+        - container_volume: /dmake.yml
+          source: ./dmake.yml
+        - container_volume: /artifacts/
+          source: ./artifacts/
       commands:
         - test "${REPO}" = 'dmake'
         - test "${REPO_SANITIZED}" = 'dmake'
         - curl -sSf "${WEB_URL}/api/factorial/?n=5"
+        - test -f /dmake.yml
+        - rm -rf /artifacts/digest && echo "${COMMIT_ID}" > /artifacts/digest
       timeout: 5


### PR DESCRIPTION
Related to #311 v0.

For now dmake doesn't really support building artifacts (such as pip
packages), but we can use `dmake test` with a mounted volume to build
artifacts and pass them to the host.

This commit simplifies this by allowing host paths relative to the
dmake.yml file for `tests.data_volumes`.