### PR TITLE
Add back dmake annotations on deployed resources

### DIFF
--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -80,8 +80,8 @@ ANNOTATE_ARGS=( "${BASE_ARGS[@]}" annotate deployment/${SERVICE} --overwrite=tru
                 ${prefix}/git-branch="${BRANCH}"
                 ${prefix}/git-revision=${COMMIT}
               )
-# echo kubectl "${ANNOTATE_ARGS[@]}"
-# kubectl "${ANNOTATE_ARGS[@]}"
+echo kubectl "${ANNOTATE_ARGS[@]}"
+kubectl "${ANNOTATE_ARGS[@]}"
 
 echo_title Rollout status for ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
 

--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -70,10 +70,11 @@ if [[ "${DMAKE_K8S_DRY_RUN}" == "1" ]]; then
   exit
 fi
 
-echo_title Annotate ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
+echo_title Annotate ${SERVICE} on kubernetes cluster ${CONTEXT}:
 # TODO currently not atomic: multiple apply can work in parallel, and this command may annotate the wrong version
 prefix="dmake.deepomatic.com"
-ANNOTATE_ARGS=( "${BASE_ARGS[@]}" annotate deployment/${SERVICE} --overwrite=true --record=false
+ANNOTATE_ARGS=( "${BASE_ARGS[@]}" annotate "${FILES_ARGS[@]}" "${FILES_NO_PRUNING_ARGS[@]}"
+                --overwrite=true --record=false
                 ${prefix}/deploy-timestamp="${deploy_timestamp}"
                 ${prefix}/service=${SERVICE}
                 ${prefix}/git-repository=${REPO}


### PR DESCRIPTION
Closes #130.

Reverts #129 now that a fix was released upstream (kubectl 1.7.14, 1.8.0).

Also annotate all resources on k8s deployment, not just the SERVICE Deployment.