### PR TITLE
Default to --dependencies & add cli options --no-dependencies, --standalone, -s

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,10 +40,7 @@ node {
 
   def self_test = (params.REPO_TO_TEST == 'deepomatic/dmake')
 
-  def dmake_with_dependencies = ''
-  if (params.DMAKE_WITH_DEPENDENCIES) {
-    dmake_with_dependencies = '--dependencies'
-  }
+  def dmake_with_dependencies = params.DMAKE_WITH_DEPENDENCIES ? '--dependencies' : '--standalone'
 
   stage('Setup') {
     checkout scm

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd tutorial
 For those who just want to see the results, just run:
 
 ```sh
-dmake run -d web
+dmake run web
 ```
 
 Once it has completed, the factorial demo is available at [http://localhost:8000](http://localhost:8000)
@@ -158,16 +158,17 @@ For most commands, `<service>` can also be `*` to target all services.
 Now that we went through the configuration file, you can try to test the worker with:
 
 ```sh
-dmake test -d worker
+dmake test worker
 ```
 
-The `-d` option tells **DMake** to run all the dependencies of the service as well.
+**DMake** will execute the `worker` tests in an enviroment where all its (runtime) dependencies are also launched. It will also recursively tests its dependencies before running them.
+You can use `--standalone` (or `-s`) to ignore the dependencies.
 
 #### `dmake shell`
 To interactively work on a service, dmake provides a shell access in the service container (running the base image), with the sources mounted into it:
 
 ```sh
-dmake shell -d worker
+dmake shell worker
 ```
 There you can build an execute your service, and quickly iterate by editting the code from your favorite editor.
 
@@ -175,7 +176,7 @@ There you can build an execute your service, and quickly iterate by editting the
 You can now run the full app with:
 
 ```sh
-dmake run -d web
+dmake run web
 ```
 It will start the `web` service with all its dependencies (RabbitMQ and the worker).
 
@@ -184,7 +185,7 @@ Once it has completed, the factorial demo is available at [http://localhost:8000
 By the way, when there are multiple application in the same repository and multiple services with the same name, you must specify the full service name like this:
 
 ```sh
-dmake run -d dmake-tutorial/web
+dmake run dmake-tutorial/web
 ```
 
 #### `dmake build`

--- a/dmake/commands/__init__.py
+++ b/dmake/commands/__init__.py
@@ -1,3 +1,2 @@
 from . import stop
-from . import deploy
 from . import release

--- a/dmake/commands/deploy.py
+++ b/dmake/commands/deploy.py
@@ -2,5 +2,5 @@ from dmake.core import make
 
 
 def entry_point(options):
-    options.dependencies = True
+    options.with_dependencies = True
     make(options)

--- a/dmake/commands/deploy.py
+++ b/dmake/commands/deploy.py
@@ -1,6 +1,0 @@
-from dmake.core import make
-
-
-def entry_point(options):
-    options.with_dependencies = True
-    make(options)

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import argparse
 import logging
 import subprocess
 import re
@@ -40,6 +41,21 @@ class SharedVolumeNotFoundException(DMakeException):
 class DockerConfigFileNotFoundException(DMakeException):
     def __init__(self, filename):
         super(DockerConfigFileNotFoundException, self).__init__('Docker config file not found (needed for registry credentials: maybe run `docker login`): %s' % (filename))
+
+###############################################################################
+
+class DependenciesBooleanAction(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        super(DependenciesBooleanAction, self).__init__(option_strings, dest, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string in ["--no-dependencies", "-s", "--standalone"]:
+            value = False
+        elif option_string in ["-d", "--dependencies"]:
+            value = True
+        else:
+            assert False, "Invalid DependenciesBooleanAction option: {}".format(option_string)
+        setattr(namespace, self.dest, value)
 
 ###############################################################################
 

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -198,8 +198,6 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
     if command == 'test' and common.skip_tests:
         return []
 
-    with_dependencies = getattr(common.options, 'dependencies', None)
-
     if node not in service_dependencies:
         if service not in service_providers:
             raise DMakeException("Cannot find service: %s" % service)
@@ -207,16 +205,16 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
         children = []
         if command == 'shell':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
-            if with_dependencies and needs is not None:
+            if common.options.with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
             children += activate_base(base_variant)
         elif command == 'test':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
-            if with_dependencies and needs is not None:
+            if common.options.with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
-            if with_dependencies:
+            if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
         elif command == 'build_docker':
             children += activate_base(base_variant)
@@ -225,7 +223,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
             if common.command in ['test', 'deploy']:
                 children += activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
-            if with_dependencies and needs is not None:
+            if common.options.with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
         elif command == 'run_link':
@@ -714,8 +712,6 @@ def make(options):
             del deps[i]
 
     is_app_only = auto_completed_app is None or auto_completed_app.find('/') < 0
-    if common.command == "run" and is_app_only:
-        common.options.dependencies = True
 
     if auto_completed_app is None:
         # Find file where changes have happened

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -117,8 +117,7 @@ class EnvBranchSerializer(YAML2PipelineSerializer):
 
         # second pass: if dependencies also to be started:
         #  add docker_links env_exports
-        with_dependencies = getattr(common.options, 'dependencies', None)
-        if with_dependencies and docker_links is not None:
+        if common.options.with_dependencies and docker_links is not None:
             # docker_links is a dictionnary of all declared links, we want to export only
             # env_export of linked services
             if needed_links is None:
@@ -128,7 +127,7 @@ class EnvBranchSerializer(YAML2PipelineSerializer):
                 for var, value in link.env_exports.items():
                     replaced_variables[var] = value
         #  and needed_services env_exports
-        if with_dependencies and needed_services is not None:
+        if common.options.with_dependencies and needed_services is not None:
             for needed_service in needed_services:
                 for var, value in needed_service.env_exports.items():
                     replaced_variables[var] = value
@@ -1483,14 +1482,14 @@ class DMakeFile(DMakeFileSerializer):
         raise DMakeException("Could not find service '%s'" % service)
 
     def _get_link_opts_(self, service):
-        if common.options.dependencies:
+        if common.options.with_dependencies:
             needed_links = service.needed_links + [ns.link_name for ns in service.needed_services if ns.link_name]
             if len(needed_links) > 0:
                 return 'dmake_return_docker_links %s %s' % (self.app_name, ' '.join(needed_links))
         return None
 
     def _get_check_needed_services_(self, commands, service):
-        if common.options.dependencies and len(service.needed_services) > 0:
+        if common.options.with_dependencies and len(service.needed_services) > 0:
             app_name = self.app_name
             # daemon name: <app_name>/<service_name><optional_unique_suffix>; needed_service.service_name doesn't contain app_name
             needed_services = map(lambda needed_service: "%s/%s%s" % (app_name, needed_service.service_name, needed_service.get_service_name_unique_suffix()), service.needed_services)

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -57,7 +57,9 @@ add_argument([parser_run],                 "service", help="Run an application o
 add_argument([parser_build],               "service", help="Build an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.")
 
 parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specified command instead of `docker.command` defined in `dmake.yml` (default: `bash`).")
-add_argument([parser_shell, parser_run, parser_test], "-d", "--dependencies", required=False, default=False, action="store_true", help="By default, the service is launched as a standalone. If this flag is specified, the dependancies of the service and links specified in the test config as run as well.")
+add_argument([parser_shell, parser_run, parser_test],
+             "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=False, dest='with_dependencies', action=common.DependenciesBooleanAction,
+             help="By default, the service is run/tested as a standalone. If this flag is set to true, the service is run/tested alongside its dependencies (service and link dependencies), recursively.")
 add_argument([parser_shell, parser_run], "-b", "--branch", required=False, default=None, help="Allow to launch the dockers with the environment variables of the given branch.")
 
 parser_release.add_argument("app", help="Create the release for the given app.")

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -57,9 +57,9 @@ add_argument([parser_run],                 "service", help="Run an application o
 add_argument([parser_build],               "service", help="Build an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.")
 
 parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specified command instead of `docker.command` defined in `dmake.yml` (default: `bash`).")
-add_argument([parser_shell, parser_run, parser_test],
-             "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=False, dest='with_dependencies', action=common.DependenciesBooleanAction,
-             help="By default, the service is run/tested as a standalone. If this flag is set to true, the service is run/tested alongside its dependencies (service and link dependencies), recursively.")
+add_argument([parser_shell, parser_run, parser_test, parser_deploy],
+             "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=True, dest='with_dependencies', action=common.DependenciesBooleanAction,
+             help="These options control if dependencies are run/tested/deployed. By default, the service is run/tested/deployed alongside its dependencies (service and link dependencies), recursively.")
 add_argument([parser_shell, parser_run], "-b", "--branch", required=False, default=None, help="Allow to launch the dockers with the environment variables of the given branch.")
 
 parser_release.add_argument("app", help="Create the release for the given app.")
@@ -70,7 +70,7 @@ parser_run.set_defaults(func=core.make)
 parser_build.set_defaults(func=core.make)
 parser_stop.set_defaults(func=commands.stop.entry_point)
 parser_shell.set_defaults(func=core.make)
-parser_deploy.set_defaults(func=commands.deploy.entry_point)
+parser_deploy.set_defaults(func=core.make)
 parser_release.set_defaults(func=commands.release.entry_point)
 
 try:

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -104,12 +104,7 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
         dmake_command = is_pr ? 'test' : 'deploy'
     }
 
-    dmake_with_dependencies = ''
-    if (params.DMAKE_WITH_DEPENDENCIES
-        && dmake_command != 'deploy')  // For now `dmake deploy` is always with dependencies, and does not support the `-d` option
-    {
-        dmake_with_dependencies = '--dependencies'
-    }
+    dmake_with_dependencies = params.DMAKE_WITH_DEPENDENCIES ? '--dependencies' : '--standalone'
 
     sh "${params.CUSTOM_ENVIRONMENT} python3 \$(which dmake) ${dmake_command} ${dmake_with_dependencies} '${params.DMAKE_APP}'"
     load 'DMakefile'


### PR DESCRIPTION
Closes #211, prerequisite for #235.

* Support cli options --no-dependencies, --standalone, -s
* Now default to `--dependencies` for dmake shell, run, test, deploy
It will avoid accidentally using remote resources (such as remote
database): use `--standalone` or `-s` to force disabling local
dependencies execution.
Also, now, `dmake deploy` can be executed without dependencie
* Update the README with the breaking change around `--dependencies`
* Update the Jenkinsfiles to use new --dependencies & --standalone