### PR TITLE
Freeze pip version to 9.0.3 when using deprecated python{,3}_requirements

### DIFF
--- a/dmake/templates/docker-base/install_pip.sh
+++ b/dmake/templates/docker-base/install_pip.sh
@@ -9,6 +9,5 @@
 if [ `which pip | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python-setuptools python-dev libffi-dev libssl-dev curl g++
-    curl https://bootstrap.pypa.io/get-pip.py | python
-    pip install --upgrade pip
+    curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3
 fi

--- a/dmake/templates/docker-base/install_pip3.sh
+++ b/dmake/templates/docker-base/install_pip3.sh
@@ -9,6 +9,5 @@
 if [ `which pip3 | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python3-setuptools python3-dev libffi-dev libssl-dev curl g++
-    curl https://bootstrap.pypa.io/get-pip.py | python3
-    pip3 install --upgrade pip
+    curl https://bootstrap.pypa.io/get-pip.py | python3 - pip==9.0.3
 fi


### PR DESCRIPTION
This avoids accidentally using newer pip with breaking changes.
Latest one: new pip 19:
```
no such option: --process-dependency-links
```

Using pip 9.0 branch as it's the one shipped in ubuntu:18.04 and it
has no major breaking change compared to previous versions.