### PR TITLE
Force deployment order using service runtime dependencies

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -231,6 +231,8 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
         elif command == 'deploy':
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             children += activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
+            if common.options.with_dependencies and needs is not None:
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'deploy')
         else:
             raise Exception("Unknown command '%s'" % command)
 

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -185,10 +185,10 @@ def activate_link(loaded_files, service_providers, service_dependencies, service
 
 ###############################################################################
 
-def activate_needed_services(loaded_files, service_providers, service_dependencies, needs):
+def activate_needed_services(loaded_files, service_providers, service_dependencies, needs, command):
     children = []
     for service, service_customization in needs:
-        children += activate_service(loaded_files, service_providers, service_dependencies, 'run', service, service_customization)
+        children += activate_service(loaded_files, service_providers, service_dependencies, command, service, service_customization)
     return children
 
 ###############################################################################
@@ -206,13 +206,13 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
         if command == 'shell':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
             if common.options.with_dependencies and needs is not None:
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
             children += activate_base(base_variant)
         elif command == 'test':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
             if common.options.with_dependencies and needs is not None:
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
@@ -224,7 +224,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
                 children += activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if common.options.with_dependencies and needs is not None:
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs)
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
         elif command == 'run_link':
             children += activate_link_shared_volumes(loaded_files, service_providers, service)


### PR DESCRIPTION
Previously it accidentally worked in some cases, and broke in
others (notably with `DMAKE_SKIP_TESTS=1`).

This is the same workaround as for `dmake test` (see #245), with the
same limits:
- when deploying a service instead of all (`*`), we now also deploy its
dependencies services. To avoid deploying (and testing) the
dependencies, use the new `--standalone` (or `-s`) flag.

Also, generalize activate_needed_services: accept any command.