### PR TITLE
Better stage name in execution plan

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -774,7 +774,7 @@ def make(options, parse_files_only=False):
 
         ordered_build_files = [('Building Base', base),
                                ('Building App', build),
-                               ('Testing App', test)]
+                               ('Running App', test)]
 
         if not common.is_pr:
             ordered_build_files.append(('Deploying', list(deploy)))


### PR DESCRIPTION
The `test` stage executes containers (except for the shell which is in
`deploy`): let's call it `Running App` instead of `Testing App` which
implies there are tests.