### PR TITLE
Allow changing branch for `dmake deploy`

### DIFF
--- a/dmake/dmake
+++ b/dmake/dmake
@@ -72,7 +72,7 @@ parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specifie
 add_argument([parser_shell, parser_run, parser_test, parser_deploy],
              "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=True, dest='with_dependencies', action=common.DependenciesBooleanAction,
              help="These options control if dependencies are run/tested/deployed. By default, the service is run/tested/deployed alongside its dependencies (service and link dependencies), recursively.")
-add_argument([parser_shell, parser_run], "-b", "--branch", required=False, default=None, help="Allow to launch the dockers with the environment variables of the given branch.")
+add_argument([parser_shell, parser_run, parser_deploy], "-b", "--branch", required=False, default=None, help="Overwrite the git branch name used to select the dmake environment")
 
 parser_release.add_argument("app", help="Create the release for the given app.")
 parser_release.add_argument('-t', '--tag', nargs='?', help="The release tag from which the release will be created.")


### PR DESCRIPTION
It could lead to accidents, but so does bypassing that by manipulating
local git branch names.