### PR TITLE
Start deprecating DMAKE_SSH_KEY for new setups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,24 +120,6 @@ if [ -f "${DMAKE_CONFIG_DIR}/config.sh" ]; then
     source "${DMAKE_CONFIG_DIR}/config.sh"
 fi
 
-if [ -z "${DMAKE_SSH_KEY}" ]; then
-    declare -a KEYS=($(ls ${HOME}/.ssh/*.pub))
-    if [ -z "${KEYS}" ]; then
-        while [ true ]; do
-            DMAKE_SSH_KEY=
-            prompt "Please type in the path to the SSH key we should use to clone private repositories ? (leave empty for none)" "DMAKE_SSH_KEY" "" "BLANK_OK"
-            if [ -f "${DMAKE_SSH_KEY}" ] || [ -z "${DMAKE_SSH_KEY}" ]; then
-                break
-            else
-                echo "No such file: ${DMAKE_SSH_KEY} ! Again:"
-            fi
-        done
-    else
-        prompt "Which SSH key should we use to clone private repositories ? (enter number)" "DMAKE_SSH_KEY" KEYS[@] "${OPTIONS[0]}"
-    fi
-    DMAKE_SSH_KEY=$(echo ${DMAKE_SSH_KEY} | sed "s/\.pub//")
-fi
-
 DMAKE_USE_HOST_PORTS=${DMAKE_USE_HOST_PORTS:-1}
 DMAKE_PUSH_BASE_IMAGE=${DMAKE_PUSH_BASE_IMAGE:-0}
 


### PR DESCRIPTION
Related to #118; it simplifies `install.sh` while still keeping the
feature for now if really needed (simply manually export
`DMAKE_SSH_KEY`).