### PR TITLE
Deprecate docker links: services can fully replace them

### DIFF
--- a/dmake/utils/dmake_run_docker_daemon
+++ b/dmake/utils/dmake_run_docker_daemon
@@ -1,16 +1,15 @@
 #!/bin/bash
 #
 # Usage:
-# ID=$(dmake_run_docker_daemon APP_NAME SERVICE_NAME LINK_NAME NAME ARGS...)
+# ID=$(dmake_run_docker_daemon APP_NAME LINK_NAME NAME ARGS...)
 #
 # Result:
 # Run a docker daemon, save container ID to list of containers to stop and return the container ID
-# if SERVICE_NAME is non-empty, save container ID as the daemon for SERVICE_NAME (in the list of daemons ID)
 # if LINK_NAME is non-empty, save container ID as the link for LINK_NAME (in <app>/links/<LINK_NAME>.id)
 
 test "${DMAKE_DEBUG}" = "1" && set -x
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 3 ]; then
     dmake_fail "$0: Missing arguments"
     echo "exit 1"
     exit 1
@@ -24,7 +23,6 @@ fi
 set -e
 
 APP_NAME=$1; shift
-SERVICE_NAME=$1; shift
 LINK_NAME=$1; shift
 NAME=$1; shift
 
@@ -44,10 +42,6 @@ while [ 1 = 1 ]; do
     fi
     sleep 1
 done
-
-if [ ! -z "${SERVICE_NAME}" ]; then
-    echo "${CONTAINER_ID} ${SERVICE_NAME}" >> ${DMAKE_TMP_DIR}/daemon_ids.txt
-fi
 
 if [ ! -z "${LINK_NAME}" ]; then
   CACHE_DIR="${DMAKE_TMP_DIR}/links/${APP_NAME}"

--- a/dmake/utils/dmake_run_docker_link
+++ b/dmake/utils/dmake_run_docker_link
@@ -38,18 +38,5 @@ while [ 1 = 1 ]; do
 done
 
 docker pull ${IMAGE_NAME} 2> /dev/null || :
-CONTAINER_ID=$(dmake_run_docker_daemon "${APP_NAME}" "" "${LINK_NAME}" "${CONTAINER_NAME}" ${OPTIONS[@]} ${VOLUMES} -i ${IMAGE_NAME})
-
-
-if [ "${PROBE_PORTS}" = "none" ]; then
-    :
-else
-    if [ "${PROBE_PORTS}" = "auto" ]; then
-        PROBE_PORTS=$(docker ps -f id=${CONTAINER_ID} --format "{{.Ports}}" | sed "s/ *//g" | sed "s/\([0-9]*\.\)\{3\}[0-9]*:[0-9]*->//g")
-    fi
-    if [ ! -z "${PROBE_PORTS}" ]; then
-        ROOT=$(dirname $0)
-        LINK_OPT="--link ${CONTAINER_ID}:${LINK_NAME}"
-        docker run --rm ${LINK_OPT} -v ${ROOT}/dmake_wait_for_it:/usr/bin/dmake_wait_for_it -v ${ROOT}/dmake_wait_for_it_wrapper:/usr/bin/dmake_wait_for_it_wrapper -i ubuntu dmake_wait_for_it_wrapper "${LINK_NAME}" "${PROBE_PORTS}"
-    fi
-fi
+CONTAINER_ID=$(dmake_run_docker_daemon "${APP_NAME}" "${LINK_NAME}" "${CONTAINER_NAME}" ${OPTIONS[@]} ${VOLUMES} -i ${IMAGE_NAME})
+dmake_wait_for_probe_ports "${CONTAINER_ID}" "${PROBE_PORTS}"

--- a/dmake/utils/dmake_run_service
+++ b/dmake/utils/dmake_run_service
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Usage:
+# ID=$(dmake_run_service APP_NAME SERVICE_NAME LINK_NAME PROBE_PORTS ARGS...)
+#
+# Result:
+# Run a docker container associated with a service, save container ID to list of containers to stop and return the container ID
+# It also saves the container ID as the daemon for SERVICE_NAME (in the list of daemons ID)
+# if LINK_NAME is non-empty, save container ID as the link for LINK_NAME (in <app>/links/<LINK_NAME>.id)
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -lt 4 ]; then
+    dmake_fail "$0: Missing arguments"
+    echo "exit 1"
+    exit 1
+fi
+
+if [ -z "${DMAKE_TMP_DIR}" ]; then
+    dmake_fail "Missing environment variable DMAKE_TMP_DIR"
+    exit 1
+fi
+
+set -e
+
+APP_NAME=$1; shift
+SERVICE_NAME=$1; shift
+LINK_NAME=$1; shift
+PROBE_PORTS=$1; shift
+
+CONTAINER_ID=$(dmake_run_docker_daemon "${APP_NAME}" "${LINK_NAME}" "" "$@")
+dmake_wait_for_probe_ports "${CONTAINER_ID}" "${PROBE_PORTS}"
+
+if [ ! -z "${SERVICE_NAME}" ]; then
+    echo "${CONTAINER_ID} ${SERVICE_NAME}" >> ${DMAKE_TMP_DIR}/daemon_ids.txt
+fi
+
+echo ${CONTAINER_ID}

--- a/dmake/utils/dmake_wait_for_probe_ports
+++ b/dmake/utils/dmake_wait_for_probe_ports
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Use this script to wait on probe ports
+#
+# Usage:
+# dmake_wait_for_probe_ports CONTAINER_ID PORTS
+#
+# Result:
+# Wait for ports to be open
+
+test "${DMAKE_DEBUG}" = "1" && set -x
+
+if [ $# -ne 2 ]; then
+    >&2 echo -e "$0: Missing arguments"
+    exit 1
+fi
+
+set -e
+
+CONTAINER_ID=${1}
+PROBE_PORTS=${2}
+
+if [ "${PROBE_PORTS}" = "none" ]; then
+    :
+else
+    if [ "${PROBE_PORTS}" = "auto" ]; then
+        PROBE_PORTS=$(docker ps -f id=${CONTAINER_ID} --format "{{.Ports}}" | sed "s/ *//g" | sed "s/\([0-9]*\.\)\{3\}[0-9]*:[0-9]*->//g")
+    fi
+    if [ ! -z "${PROBE_PORTS}" ]; then
+        ROOT=$(dirname $0)
+        >&2 docker run --rm --link ${CONTAINER_ID}:link_to_wait -v ${ROOT}/dmake_wait_for_it:/usr/bin/dmake_wait_for_it -v ${ROOT}/dmake_wait_for_it_wrapper:/usr/bin/dmake_wait_for_it_wrapper -i ubuntu dmake_wait_for_it_wrapper "link_to_wait" "${PROBE_PORTS}"
+    fi
+fi


### PR DESCRIPTION
Docker links duplicate many notions and are not necessary. In order to unify how we handle the various concepts in a deployment pipeline, let's get rid of them.

### Migration indications:

For each link, create a service. Use the following mapping to update the service definition:

| Before       |     After    |
| :------------ | :------------- |
| `docker_links`::`image_name`      | `services`::`config`::`docker_image` |
| `docker_links`::`link_name`       | `services`::`service_name` |
| `docker_links`::`probe_ports`     | `services`::`config`::`probe_ports` |
| `docker_links`::`env`             | `services`::`config`::`env_override` |
| `docker_links`::`volumes`         | `services`::`config`::`volumes` |
| `docker_links`::`need_gpu`        | `services`::`config`::`need_gpu` |
| `docker_links`::`testing_options` | `services`::`config`::`docker_opts` |
| `docker_links`::`env_exports`     | `services`::`needed_services`::`env_exports` |

I'm not sure the last one will work, why is it injected when calling needed_services ? Anyway, I haven't changed this behavior here.
