### PR TITLE
Replacing temp file used to return variables (issue #383)

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -107,6 +107,8 @@ def append_command(commands, cmd, prepend = False, **args):
         check_cmd(args, ['message'])
     elif cmd == "sh":
         check_cmd(args, ['shell'])
+    elif cmd == "assign_var":
+        check_cmd(args, ['var', 'shell'])
     elif cmd == "read_sh":
         check_cmd(args, ['var', 'shell'], optional = ['fail_if_empty'])
         if 'fail_if_empty' not in args:

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -9,8 +9,6 @@ from dmake.deepobuild import DMakeFile
 
 tag_push_error_msg = "Unauthorized to push the current state of deployment to git server. If the repository belongs to you, please check that the credentials declared in the DMAKE_JENKINS_SSH_AGENT_CREDENTIALS and DMAKE_JENKINS_HTTP_CREDENTIALS allow you to write to the repository."
 
-# List that stores all the generated variables
-VARIABLES = []
 ###############################################################################
 
 def find_symlinked_directories():
@@ -483,11 +481,8 @@ def generate_command_pipeline(file, cmds):
                 write_line(')')
         elif cmd == "assign_var":
             name = kwargs['var']
-            if name not in VARIABLES:
-               write_line("def %s = sh(script:'%s', returnStdout: true).trim()" % (name, kwargs['shell']))
-               VARIABLES.append(name)
-            else:
-               write_line("%s = sh(script:'%s', returnStdout: true).trim()" % (name, kwargs['shell']))
+            # NOTE: Be aware, this assignment generates a global variable and not a scoped one.
+            write_line("%s = sh(script:'%s', returnStdout: true).trim()" % (name, kwargs['shell']))
         elif cmd == "read_sh":
             file_output = os.path.join(common.cache_dir, "output_%s" % uuid.uuid4())
             write_line("sh('%s > %s')" % (kwargs['shell'], file_output))

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1334,14 +1334,15 @@ class DMakeFile(DMakeFileSerializer):
         docker_opts += service.tests.get_mounts_opt(service_name, self.__path__, env)
         docker_cmd = 'dmake_run_docker_daemon "%s" "%s" "%s" "" %s -i %s' % (self.app_name, unique_service_name, link_name or "", docker_opts, image_name)
         docker_cmd = service.get_docker_run_gpu_cmd_prefix() + docker_cmd
-
         # Run daemon
-        append_command(commands, 'read_sh', var = "DAEMON_ID", shell = docker_cmd)
+        append_command(commands, 'assign_var', var = "DAEMON_ID", shell = docker_cmd)
 
         # Wait for daemon to be ready
         cmd = service.config.readiness_probe.get_cmd()
         if cmd:
+            append_command(commands, 'with_env', value = [("DAEMON_ID", "${DAEMON_ID}")])
             append_command(commands, 'sh', shell = 'dmake_exec_docker ${DAEMON_ID} %s' % cmd)
+            append_command(commands, 'with_env_end')
 
     def generate_build_docker(self, commands, service_name):
         service = self._get_service_(service_name)


### PR DESCRIPTION
Closes #383 

**Before**
```
    sh('dmake_run_docker_daemon "vulcan" "vulcan/init-db---5691079760623584708" "" "" --env-file /tmp/dmake_tmp_1558450334962678058_23997/env.txt.d1d3df94-0780-49f9-aee7-9297d7c71556   $(dmake_return_docker_links vulcan postgres) -i init-db:dev-jenkins-up2-slave-82 > /var/jenkins_home/jobs/vulcan-test-multi-node/branches/dev-jenkins-up2-slave/workspace@2/.dmake/output_0dd6e73b-a517-4b02-a939-c926d94b2cc1')
    env.DAEMON_ID = readFile '/var/jenkins_home/jobs/vulcan-test-multi-node/branches/dev-jenkins-up2-slave/workspace@2/.dmake/output_0dd6e73b-a517-4b02-a939-c926d94b2cc1'
    sh("dmake_exec_docker \${DAEMON_ID} bash -c \"T=0; sleep 0; while [ 1 ]; do echo \\\"Running readiness probe\\\"; ls \\\"/tmp/init-db-ready\\\"; if [ \\\"\\\$?\\\" = \\\"0\\\" ]; then echo \\\"... ready\\\"; exit 0; fi; T=\\\$((T+5)); sleep 5; done; exit 1;\"")
```

**After**
```
    def DAEMON_ID = sh(script:'dmake_run_docker_daemon "vulcan" "vulcan/init-db---2965137994837651050" "" "" --env-file /tmp/dmake_tmp_1558450224598011660_11366/env.txt.99f44ac6-dd52-4269-9c91-5b4eafb3f729   $(dmake_return_docker_links vulcan postgres) -i init-db:dev-jenkins-up2-slave-82', returnStdout: true).trim()
    withEnv([
      "DAEMON_ID=${DAEMON_ID}"]) {
      sh("dmake_exec_docker \${DAEMON_ID} bash -c \"T=0; sleep 0; while [ 1 ]; do echo \\\"Running readiness probe\\\"; ls \\\"/tmp/init-db-ready\\\"; if [ \\\"\\\$?\\\" = \\\"0\\\" ]; then echo \\\"... ready\\\"; exit 0; fi; T=\\\$((T+5)); sleep 5; done; exit 1;\"")
    } // end env
```