### PR TITLE
Add --[no-]docker-links-volumes-persistence option to dmake run

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -57,6 +57,17 @@ class DependenciesBooleanAction(argparse.Action):
             assert False, "Invalid DependenciesBooleanAction option: {}".format(option_string)
         setattr(namespace, self.dest, value)
 
+class FlagBooleanAction(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        super(FlagBooleanAction, self).__init__(option_strings, dest, nargs=0, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if option_string.startswith("--no-"):
+            value = False
+        else:
+            value = True
+        setattr(namespace, self.dest, value)
+
 ###############################################################################
 
 def yaml_ordered_load(stream, all=False):

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -405,14 +405,19 @@ class DockerLinkSerializer(YAML2PipelineSerializer):
 
     def get_options(self, path, env):
         options = common.eval_str_in_env(self.testing_options, env)
-        in_shell = common.command == "shell"
+
+        if hasattr(common.options, 'with_docker_links_volumes_persistence'):
+            volume_persistence = common.options.with_docker_links_volumes_persistence
+        else:
+            # skip host vols in non shell (i.e. in test: we don't want persistence)
+            volume_persistence = (common.command == "shell")
+
         for volume in self.volumes:
             if isinstance(volume, SharedVolumeMountSerializer):
                 # named shared volume
                 options += ' ' + volume.get_mount_opt(env)
             elif isinstance(volume, VolumeMountSerializer):
-                if not in_shell:
-                    # skip host vols in non shell (i.e. in test: we don't want persistence)
+                if not volume_persistence:
                     continue
                 host_vol = common.eval_str_in_env(volume.host_volume, env)
 

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -74,6 +74,8 @@ add_argument([parser_shell, parser_run, parser_test, parser_deploy],
              help="These options control if dependencies are run/tested/deployed. By default, the service is run/tested/deployed alongside its dependencies (service and link dependencies), recursively.")
 add_argument([parser_shell, parser_run, parser_deploy, parser_stop], "-b", "--branch", required=False, default=None, help="Overwrite the git branch name used to select the dmake environment")
 
+parser_run.add_argument("--docker-links-volumes-persistence", "--no-docker-links-volumes-persistence", required=False, default=False, dest='with_docker_links_volumes_persistence', action=common.FlagBooleanAction, help="Control persistence of docker-links volumes (default: non-persistent (for dmake run)).")
+
 parser_release.add_argument("app", help="Create the release for the given app.")
 parser_release.add_argument('-t', '--tag', nargs='?', help="The release tag from which the release will be created.")
 


### PR DESCRIPTION
Closes #317.

Sometimes we want persistence with `dmake run`, and sometimes we
don't (running multiple instances of the application at the same time
would break things with persistence by host mount).

Keep the default of non persistence for `dmake run`.

Only add the option to `dmake run` for now.

- `dmake shell` remains always persistent
- `dmake test` remains never persistent
- Shared volumes remains never persistent