### PR TITLE
Remove docker_opt is_public clean

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -890,8 +890,7 @@ class DeployConfigSerializer(YAML2PipelineSerializer):
             opts.append("-v %s:%s" % (common.join_without_slash(host_volume), common.join_without_slash(volume.container_volume)))
 
         docker_opts = self.docker_opts
-        opts = docker_opts + " " + (" ".join(opts))
-        return opts
+        return docker_opts + " " + (" ".join(opts))
 
 class DeploySerializer(YAML2PipelineSerializer):
     deploy_name = FieldSerializer("string", optional = True, example = "", help_text = "The name used for deployment. Will default to '{:app_name}-{:service_name}' if not specified")

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -890,8 +890,6 @@ class DeployConfigSerializer(YAML2PipelineSerializer):
             opts.append("-v %s:%s" % (common.join_without_slash(host_volume), common.join_without_slash(volume.container_volume)))
 
         docker_opts = self.docker_opts
-        if not common.is_local:
-            docker_opts = docker_opts.replace('--privileged', '')
         opts = docker_opts + " " + (" ".join(opts))
         return opts
 


### PR DESCRIPTION
Closes #397 

We need to access `/dev` with `--privileged` on Jenkins for hardware support.
Unfortunately dmake removed `--privileged` from `docker_opts` when the build was not local.
It was not really useful a protection: just remove it.