### PR TITLE
Always chmod 777 the shared volumes

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -128,9 +128,7 @@ class SharedVolumeSerializer(YAML2PipelineSerializer):
         return result
 
     def _serialize_(self, commands, path_dir):
-        cmd = "dmake_create_docker_shared_volume %s" % (self.id)
-        if common.command == "shell":
-            cmd += " 777"
+        cmd = "dmake_create_docker_shared_volume %s 777" % (self.id)
         append_command(commands, 'sh', shell = cmd)
 
     def get_service_name(self):


### PR DESCRIPTION
Previously we did it for dmake shell so there is no issue related to
DMAKE_UID, but in fact we also need it for dmake run/test: sometimes
the containers have non root users and must be able to write to the
shared volume anyway.

Furthermore, the kubernetes equivalent (emptyDir) does that too.