### PR TITLE
kubernetes yaml: better multi document concatenation

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -92,6 +92,8 @@ def yaml_ordered_dump(data, stream=None, default_flow_style=False, all=False, no
         stream = StringIO()
         return_string = True
     yaml = YAML(pure=True)
+    # simplify concatenating yaml files
+    yaml.explicit_start = True
     # kubernetes reads yaml 1.1, notably interprets `no` as boolean instead of string vs default ruamel which dumps yaml 1.2
     yaml.version = '1.1'
     # kubectl does not tolerate %YAML 1.1 directive, disabling it

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -742,8 +742,8 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
                 return
             manifest_files.append(filename)
             data = [source.generate_manifest(env=env, labels=extra_labels) for source in sources]
-            # concat manifests
-            data_str = '%s\n' % ('\n\n---\n\n'.join(data))
+            # concat manifests, no need for `---\n` because explicit_start are added when dumping yaml in k8s_utils.generate_from_create() in source.generate_manifest().
+            data_str = '%s\n' % ('\n\n'.join(data))
             # write manifests to file
             with open(os.path.join(tmp_dir, filename), 'w') as f:
                 k8s_utils.dump_all_str_and_add_labels(data_str, dmake_generated_labels, f)


### PR DESCRIPTION
It is then robust to %YAML headers (otherwise it would generate empty
sections that would crash dmake later on).

Fix regression introduced in #402.