### PR TITLE
Support extra characters in branch name

### DIFF
--- a/dmake/commands/stop.py
+++ b/dmake/commands/stop.py
@@ -3,4 +3,4 @@ import dmake.common as common
 
 def entry_point(options):
     common.logger.info('Stopping all containers for current repo and branch.')
-    common.run_shell_command('CONTAINER_IDS=$(docker ps -q -f name=%s.%s.%s); test -n "${CONTAINER_IDS}" && docker rm -f ${CONTAINER_IDS}' % (common.repo, common.branch, common.build_id))
+    common.run_shell_command('CONTAINER_IDS=$(docker ps -q -f name=%s); test -n "${CONTAINER_IDS}" && docker rm -f ${CONTAINER_IDS}' % (common.name_prefix))

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -436,12 +436,6 @@ def init(_options, early_exit=False):
             branch = "PR-%s" % pr_id
         if branch is None:
             branch = run_shell_command("git rev-parse --abbrev-ref HEAD")
-        if branch is not None:
-            branch = branch.split('/')
-            if len(branch) > 1:
-                branch = '/'.join(branch[1:])
-            else:
-                branch = branch[0]
     else:
         target   = os.getenv('CHANGE_TARGET', None)
         pr_id    = os.getenv('CHANGE_ID')

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -354,7 +354,7 @@ def dump_dot_graph(dependencies, attributes):
 def init(_options, early_exit=False):
     global generate_dot_graph, exit_after_generate_dot_graph, dot_graph_filename, dot_graph_format
     global root_dir, sub_dir, tmp_dir, config_dir, cache_dir, relative_cache_dir, key_file
-    global branch, target, is_pr, pr_id, build_id, commit_id, force_full_deploy
+    global branch, target, is_pr, pr_id, build_id, commit_id, name_prefix, force_full_deploy
     global remote, repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
     global no_gpu, need_gpu
     global build_description
@@ -485,6 +485,9 @@ def init(_options, early_exit=False):
         repo_github_owner = repo_github_owner.groups()[0]
     commit_id = run_shell_command('git rev-parse HEAD')
 
+    # Generate name prefix: readable, unique, stable identifier
+    name_prefix = sanitize_name_unique('{repo}.{branch}.{build_id}'.format(repo=repo, branch=branch, build_id=build_id), mode='docker')
+
     # Set Job description
     build_description = None
     if use_pipeline:
@@ -522,6 +525,7 @@ def init(_options, early_exit=False):
     else:
         logger.info("BRANCH : %s" % branch)
     logger.info("COMMIT_ID : %s" % commit_id[:7])
+    logger.info("NAME_PREFIX : %s" % name_prefix)
     logger.info("===============")
 
     # Check the SSH Key for cloning private repositories is correctly set up

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -792,6 +792,7 @@ def make(options, parse_files_only=False):
     append_command(all_commands, 'env', var = "COMMIT", value = common.commit_id)
     append_command(all_commands, 'env', var = "BUILD", value = common.build_id)
     append_command(all_commands, 'env', var = "BRANCH", value = common.branch)
+    append_command(all_commands, 'env', var = "NAME_PREFIX", value = common.name_prefix)
     append_command(all_commands, 'env', var = "DMAKE_TMP_DIR", value = common.tmp_dir)
     # check DMAKE_TMP_DIR still exists: detects unsupported jenkins reruns: clear error
     append_command(all_commands, 'sh', shell = 'dmake_check_tmp_dir')

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -124,7 +124,7 @@ class SharedVolumeSerializer(YAML2PipelineSerializer):
         SharedVolumes.register(self, file)
         # unique volume name
         # docker seems to limit around 256, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
-        self.id = '{repo}.{branch}.{build_id}.{session_id}.{name}'.format(name=self.name, **vars(common))
+        self.id = '{name_prefix}.{session_id}.{name}'.format(name_prefix=common.name_prefix, session_id=common.session_id, name=self.name)
         return result
 
     def _serialize_(self, commands, path_dir):

--- a/dmake/docker_image.py
+++ b/dmake/docker_image.py
@@ -93,7 +93,7 @@ class ServiceDockerCommonSerializer(YAML2PipelineSerializer, AbstractDockerImage
     name             = FieldSerializer("string", optional = True, help_text = "Name of the docker image to build. By default it will be {:app_name}-{:service_name}. If there is no docker user, it won be pushed to the registry. You can use environment variables.")
     base_image_variant = FieldSerializer(["string", "array"], optional = True, child = "string", help_text = "Specify which `base_image` variants are used as `base_image` for this service. Array: multi-variant service. Default: first 'docker.base_image'.")
     check_private    = FieldSerializer("bool", default = True, help_text = "Check that the docker repository is private before pushing the image.")
-    tag              = FieldSerializer("string", optional = True, help_text = "Tag of the docker image to build. By default it will be '[{:variant}-]{:branch_name}-{:build_id}'")
+    tag              = FieldSerializer("string", optional = True, help_text = "Tag of the docker image to build. By default it will be '[{:variant}-]{:branch_name}-{:build_id}', sanitized and made unique with a hash suffix if needed")
 
     def get_image_name(self, env=None, latest=False):
         if env is None:
@@ -105,7 +105,7 @@ class ServiceDockerCommonSerializer(YAML2PipelineSerializer, AbstractDockerImage
             name = common.eval_str_in_env(self.name, env)
         # tag
         if self.tag is None:
-            tag = common.branch.lower()
+            tag = common.sanitize_name_unique(common.branch, mode='docker')
             if latest:
                 tag += "-latest"
             else:

--- a/dmake/test_common.py
+++ b/dmake/test_common.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from dmake.common import sanitize_name
+from dmake.common import sanitize_name, sanitize_name_unique
 
 
 @pytest.mark.parametrize("test_input,expected", [
@@ -11,10 +11,32 @@ from dmake.common import sanitize_name
     ('foo_bar', 'foo-bar'),
     ('Foo_BAR', 'foo-bar'),
     ('-foo', 'foo'),
+    ('#foo', 'foo'),
     ('foo__bar', 'foo-bar'),
     ('dev-#123', 'dev--123'),
     ('foo/bar', 'foo-bar'),
 ])
-def test_sanitize_name(test_input, expected):
+def test_sanitize_name_kubernetes(test_input, expected):
     assert sanitize_name(test_input) == expected
     assert re.match(r'[a-z0-9]([-a-z0-9]*[a-z0-9])?', sanitize_name(test_input))
+
+@pytest.mark.parametrize("test_input,expected", [
+    ('test', 'test'),
+    ('Test', 'Test'),
+    ('foo_Bar', 'foo_Bar'),
+    ('-foo', 'foo'),
+    ('_foo', 'foo'),
+    ('.foo', 'foo'),
+    ('#foo', 'foo'),
+    ('foo#bar', 'foo-bar'),
+    ('foo##bar', 'foo-bar'),
+    ('foo/bar#baz', 'foo-bar-baz'),
+])
+def test_sanitize_name_docker(test_input, expected):
+    assert sanitize_name(test_input, mode='docker') == expected
+    assert re.match(r'[a-zA-Z0-9][a-zA-Z0-9_.-]+', sanitize_name(test_input, mode='docker'))
+
+def test_sanitize_name_unique():
+    assert sanitize_name_unique('foo_bar', mode='docker') == 'foo_bar', "When no sanitation is needed it should return identity"
+    assert sanitize_name_unique('foo/bar', mode='docker') != sanitize_name_unique('foo#bar', mode='docker'), "Same sanitization should still be unique"
+    assert sanitize_name_unique('foo/bar', mode='docker') == sanitize_name_unique('foo/bar', mode='docker'), "Sanitation should be stable"

--- a/dmake/utils/dmake_run_docker
+++ b/dmake/utils/dmake_run_docker
@@ -29,11 +29,7 @@ NAME=$2
 shift 2
 
 if [ -z "${NAME}" ]; then
-    if [ ! -z "${BUILD}" ]; then
-        PREFIXED_BUILD=".${BUILD}"
-    fi
-
-    BASE_NAME="${REPO}.${BRANCH}${PREFIXED_BUILD}.tmp"
+    BASE_NAME="${NAME_PREFIX}.tmp"
 
     while [ 1 = 1 ]; do
         NAME=$BASE_NAME.$RANDOM

--- a/dmake/utils/dmake_run_docker_link
+++ b/dmake/utils/dmake_run_docker_link
@@ -26,7 +26,7 @@ LINK_NAME=$1; shift
 PROBE_PORTS=$1; shift
 OPTIONS=( $@ )
 
-BASE_NAME=${REPO}.${BRANCH}.${BUILD}.${APP_NAME}.${LINK_NAME}
+BASE_NAME=${NAME_PREFIX}.${LINK_NAME}
 
 COUNT=0
 while [ 1 = 1 ]; do


### PR DESCRIPTION
Closes #23, dmake should finally support dependabot.

- Add docker mode for sanitation, and add a unique variant
- Factorize docker image name prefix in a new global: name_prefix
- Sanitize the default docker image tag name: git branches can contain invalid characters
- Support git branches with slashes