### PR TITLE
Add IMAGE_TAG_PREFIX host environment variable

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -354,7 +354,7 @@ def dump_dot_graph(dependencies, attributes):
 def init(_options, early_exit=False):
     global generate_dot_graph, exit_after_generate_dot_graph, dot_graph_filename, dot_graph_format
     global root_dir, sub_dir, tmp_dir, config_dir, cache_dir, relative_cache_dir, key_file
-    global branch, target, is_pr, pr_id, build_id, commit_id, name_prefix, force_full_deploy
+    global branch, target, is_pr, pr_id, build_id, commit_id, name_prefix, image_tag_prefix, force_full_deploy
     global remote, repo_url, repo, use_pipeline, is_local, skip_tests, is_release_branch
     global no_gpu, need_gpu
     global build_description
@@ -482,6 +482,9 @@ def init(_options, early_exit=False):
     # Generate name prefix: readable, unique, stable identifier
     name_prefix = sanitize_name_unique('{repo}.{branch}.{build_id}'.format(repo=repo, branch=branch, build_id=build_id), mode='docker')
 
+    # Generate default image tag prefix
+    image_tag_prefix = sanitize_name_unique(branch, mode='docker')
+
     # Set Job description
     build_description = None
     if use_pipeline:
@@ -506,6 +509,7 @@ def init(_options, early_exit=False):
     os.environ["BUILD"]       = str(build_id)
     os.environ["REPO_SANITIZED"]   = sanitize_name(repo)
     os.environ["BRANCH_SANITIZED"] = sanitize_name(str(branch))
+    os.environ["IMAGE_TAG_PREFIX"] = image_tag_prefix
 
     if early_exit:
         return

--- a/dmake/docker_image.py
+++ b/dmake/docker_image.py
@@ -105,7 +105,7 @@ class ServiceDockerCommonSerializer(YAML2PipelineSerializer, AbstractDockerImage
             name = common.eval_str_in_env(self.name, env)
         # tag
         if self.tag is None:
-            tag = common.sanitize_name_unique(common.branch, mode='docker')
+            tag = common.image_tag_prefix
             if latest:
                 tag += "-latest"
             else:

--- a/test/e2e/dmake.yml
+++ b/test/e2e/dmake.yml
@@ -6,6 +6,7 @@ env:
     variables:
       REPO: ${REPO}
       REPO_SANITIZED: ${REPO_SANITIZED}
+      IMAGE_TAG_PREFIX: ${IMAGE_TAG_PREFIX}
       COMMIT_ID: ${COMMIT_ID}
 
 docker:
@@ -41,6 +42,7 @@ services:
       commands:
         - test "${REPO}" = 'dmake'
         - test "${REPO_SANITIZED}" = 'dmake'
+        - bash -xc "[[ \"${IMAGE_TAG_PREFIX}\" =~ [a-zA-Z0-9][a-zA-Z0-9_.-]+ ]]"
         - curl -sSf "${NGINX_URL}"
         - curl -sSf "${WEB_URL}/api/factorial/?n=5"
         - test -f /dmake.yml

--- a/tutorial/e2e/dmake.yml
+++ b/tutorial/e2e/dmake.yml
@@ -5,6 +5,7 @@ env:
   default:
     variables:
       NAME: ${REPO_SANITIZED}-${BRANCH_SANITIZED}-${BUILD}
+      IMAGE_TAG_PREFIX: ${IMAGE_TAG_PREFIX}
 
 docker:
   root_image:
@@ -25,6 +26,6 @@ services:
           dockerfile: ./deploy/Dockerfile
     tests:
       commands:
-        - echo running tutorial from ${NAME}
+        - echo running tutorial from ${NAME} with image tag prefix ${IMAGE_TAG_PREFIX}
         - curl -sSf "${WEB_URL}/api/factorial/?n=5"
       timeout: 5


### PR DESCRIPTION
It allows applications to reconstruct dmake built docker images tags
more easily (notably since #407).