### PR TITLE
Default prompt choice for a deploy command will be no

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -882,7 +882,7 @@ def make(options, parse_files_only=False):
     common.logger.info("Commands have been written to %s" % file_to_generate)
 
     if common.command == "deploy" and common.is_local:
-        r = common.read_input("Careful ! Are you sure you want to deploy ? [N/y] ")
+        r = common.read_input("Careful ! Are you sure you want to deploy ? [y/N] ")
         if r.lower() != 'y':
             print('Aborting')
             sys.exit(0)

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -882,8 +882,8 @@ def make(options, parse_files_only=False):
     common.logger.info("Commands have been written to %s" % file_to_generate)
 
     if common.command == "deploy" and common.is_local:
-        r = common.read_input("Careful ! Are you sure you want to deploy ? [Y/n] ")
-        if r.lower() != 'y' and r != "":
+        r = common.read_input("Careful ! Are you sure you want to deploy ? [N/y] ")
+        if r.lower() != 'y':
             print('Aborting')
             sys.exit(0)
 


### PR DESCRIPTION
close #405 
```
Commands have been written to /tmp/dmake_tmp_1569951000375351679_17527/DMakefile
Careful ! Are you sure you want to deploy ? [y/N]  y
```
or 
```
Commands have been written to /tmp/dmake_tmp_1569951200428491684_10785/DMakefile
Careful ! Are you sure you want to deploy ? [y/N]  
Aborting
```