### PR TITLE
Add DMake internal plan graph tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+*~
 *.pyc
 .venv
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ node {
     sh ". workspace/.venv2/bin/activate && pip install -r requirements.txt"
     dir('workspace') {
       if (self_test) {
-        sh ". .venv2/bin/activate && pytest -v --junit-xml=junit.xml --junit-prefix=python2"
+        sh ". .venv2/bin/activate && pytest -vv --junit-xml=junit.xml --junit-prefix=python2"
         junit keepLongStdio: true, testResults: 'junit.xml'
       }
       sh ". .venv2/bin/activate && ${params.CUSTOM_ENVIRONMENT} dmake ${params.DMAKE_COMMAND} ${dmake_with_dependencies} '${params.DMAKE_APP_TO_TEST}'"
@@ -106,7 +106,7 @@ node {
     sh ". workspace/.venv3/bin/activate && pip install -r requirements.txt"
     dir('workspace') {
       if (self_test) {
-        sh ". .venv3/bin/activate && pytest -v --junit-xml=junit.xml --junit-prefix=python3"
+        sh ". .venv3/bin/activate && pytest -vv --junit-xml=junit.xml --junit-prefix=python3"
         junit keepLongStdio: true, testResults: 'junit.xml'
       }
       sh ". .venv3/bin/activate && ${params.CUSTOM_ENVIRONMENT} dmake ${params.DMAKE_COMMAND} ${dmake_with_dependencies} '${params.DMAKE_APP_TO_TEST}'"

--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -1,0 +1,106 @@
+import sys
+import os
+import argcomplete
+import argparse
+import dmake.commands as commands
+import dmake.core as core
+import dmake.common as common
+
+
+def check_is_git_repo():
+    try:
+        common.run_shell_command('git rev-parse --abbrev-ref HEAD')
+        return True
+    except common.ShellError as e:
+        common.logger.error("Current directory is not a Git repository:\n%s" % str(e))
+        return False
+
+
+def add_argument(parsers, *args, **kwargs):
+    for parser in parsers:
+        parser.add_argument(*args, **kwargs)
+
+
+def completion_action(args):
+    print(argcomplete.shellcode('dmake', shell=args.shell))
+
+
+# Find root
+try:
+    root_dir, sub_dir = common.find_repo_root()
+except common.ShellError as e:
+    common.logger.error("Current directory is not a Git repository:\n%s" % str(e))
+    sys.exit(1)
+os.chdir(root_dir)
+
+# Defines command line parser
+argparser = argparse.ArgumentParser(prog='dmake')
+
+argparser.add_argument('--debug-graph', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes.")
+argparser.add_argument('--debug-graph-and-exit', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes then exit.")
+argparser.add_argument('--debug-graph-output-filename', default='dmake-services.gv', help="The generated DOT graph filename.")
+argparser.add_argument('--debug-graph-output-format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
+
+subparsers = argparser.add_subparsers(dest='cmd', title='Commands')
+subparsers.required = True
+
+parser_test    = subparsers.add_parser('test', help="Launch tests for the whole repo or, if specified, an app or one of its services.")
+parser_build   = subparsers.add_parser('build', help="Launch the build for the whole repo or, if specified, an app or one of its services.")
+parser_run     = subparsers.add_parser('run', help="Launch the application or only one of its services.")
+parser_stop    = subparsers.add_parser('stop', help="Stop the containers lauched with 'dmake run'.")
+parser_shell   = subparsers.add_parser('shell', help="Run a shell session withing a docker container with the environment set up for a given service.")
+parser_deploy  = subparsers.add_parser('deploy', help="Deploy specified apps and services.")
+parser_release = subparsers.add_parser('release', help="Create a release of the app on Github.")
+
+
+# "service" argument
+for parser in [parser_test, parser_deploy]:
+    parser.add_argument("service", nargs='?', default='*', help="Apply command to the full repository or, if specified, to the app/service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
+for parser in [parser_shell]:
+    parser.add_argument("service", nargs='?', default='.', help="Run a shell session withing the docker base image for the given service. You may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
+for parser in [parser_run]:
+    parser.add_argument("service", help="Run an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
+for parser in [parser_build]:
+    parser.add_argument("service", help="Build an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
+
+parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specified command instead of `docker.command` defined in `dmake.yml` (default: `bash`).")
+add_argument([parser_shell, parser_run, parser_test, parser_deploy],
+             "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=True, dest='with_dependencies', action=common.DependenciesBooleanAction,
+             help="These options control if dependencies are run/tested/deployed. By default, the service is run/tested/deployed alongside its dependencies (service and link dependencies), recursively.")
+add_argument([parser_shell, parser_run, parser_deploy, parser_stop], "-b", "--branch", required=False, default=None, help="Overwrite the git branch name used to select the dmake environment")
+
+parser_run.add_argument("--docker-links-volumes-persistence", "--no-docker-links-volumes-persistence", required=False, default=False, dest='with_docker_links_volumes_persistence', action=common.FlagBooleanAction, help="Control persistence of docker-links volumes (default: non-persistent (for dmake run)).")
+
+parser_release.add_argument("app", help="Create the release for the given app.")
+parser_release.add_argument('-t', '--tag', nargs='?', help="The release tag from which the release will be created.")
+
+parser_test.set_defaults(func=core.make)
+parser_run.set_defaults(func=core.make)
+parser_build.set_defaults(func=core.make)
+parser_stop.set_defaults(func=commands.stop.entry_point)
+parser_shell.set_defaults(func=core.make)
+parser_deploy.set_defaults(func=core.make)
+parser_release.set_defaults(func=commands.release.entry_point)
+
+
+# Shell completion
+parser_completion = subparsers.add_parser('completion',
+                                          help="Output shell completion code for bash (may work for zsh)",
+                                          formatter_class=argparse.RawDescriptionHelpFormatter,
+                                          description="""
+This command can generate shell autocompletions. e.g.
+
+    $ dmake completion
+
+Can be sourced as such
+
+    $ source <(dmake completion)
+
+./install.sh should have already installed everything in:
+- ${HOME}/.dmake/completion.bash.inc
+- ${HOME}/.dmake/config.sh
+- ${HOME}/.bashrc
+""",
+                                          )
+parser_completion.add_argument("shell", nargs='?', default='bash', choices=['bash'], help="Shell to emit completion for")
+parser_completion.set_defaults(func=completion_action)

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -317,7 +317,7 @@ def get_dmake_build_type():
 
 ###############################################################################
 
-def dump_dot_graph(dependencies, attributes):
+def dump_dot_graph(dependencies, nodes_height):
     if not generate_dot_graph:
         return
 
@@ -329,8 +329,8 @@ def dump_dot_graph(dependencies, attributes):
 
     def node2label(node):
         label = '{}\n{}\n{}'.format(*node)
-        if node in attributes:
-            label += '\n{}'.format(attributes[node])
+        if node in nodes_height:
+            label += '\nheight={}'.format(nodes_height[node])
         return label
 
     dot = Digraph(comment='DMake Services', filename=dot_graph_filename, format=dot_graph_format)
@@ -338,24 +338,26 @@ def dump_dot_graph(dependencies, attributes):
 
     # group nodes by commands
     commands = {}
-    for node, deps in dependencies.items():
+    for node, deps in sorted(dependencies.items()):
         command = node[0]
         if command not in commands:
             commands[command] = []
         commands[command].append((node, deps))
-    for command, nodes_deps in commands.items():
+    for command, nodes_deps in sorted(commands.items()):
         # sub graph with same rank: horizontal node alignment per command
         with dot.subgraph() as s:
             s.attr(rank='same')
-            for node, deps in nodes_deps:
+            for node, deps in sorted(nodes_deps):
                 # create nodes
                 s.node(node2node_id(node), label=node2label(node))
-                for dep in deps:
+                for dep in sorted(deps):
                     # create edges
                     dot.edge(node2node_id(node), node2node_id(dep))
 
-    dot.render()
-    logger.info("Generated debug DOT graph: '%s' and '%s'" % (dot_graph_filename, dot_graph_filename + '.' + dot_graph_format))
+    if dot_graph_filename is not None:
+        dot.render()
+        logger.info("Generated debug DOT graph: '%s' and '%s'" % (dot_graph_filename, dot_graph_filename + '.' + dot_graph_format))
+    return dot
 
 ###############################################################################
 

--- a/dmake/dmake
+++ b/dmake/dmake
@@ -2,120 +2,19 @@
 # PYTHON_ARGCOMPLETE_OK
 
 import sys
-import os
 import argcomplete
-import argparse
-import dmake.commands as commands
-import dmake.core as core
 import dmake.common as common
 from dmake.common import DMakeException
 
+import dmake.cli as cli
 
-def check_is_git_repo():
+if __name__ == "__main__":
     try:
-        common.run_shell_command('git rev-parse --abbrev-ref HEAD')
-        return True
-    except common.ShellError as e:
-        common.logger.error("Current directory is not a Git repository:\n%s" % str(e))
-        return False
-
-
-def add_argument(parsers, *args, **kwargs):
-    for parser in parsers:
-        parser.add_argument(*args, **kwargs)
-
-
-def completion_action(args):
-    print(argcomplete.shellcode('dmake', shell=args.shell))
-
-
-
-# Find root
-try:
-    root_dir, sub_dir = common.find_repo_root()
-except common.ShellError as e:
-    common.logger.error("Current directory is not a Git repository:\n%s" % str(e))
-    sys.exit(1)
-os.chdir(root_dir)
-
-# Defines command line parser
-argparser = argparse.ArgumentParser(prog='dmake')
-
-argparser.add_argument('--debug-graph', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes.")
-argparser.add_argument('--debug-graph-and-exit', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes then exit.")
-argparser.add_argument('--debug-graph-output-filename', default='dmake-services.gv', help="The generated DOT graph filename.")
-argparser.add_argument('--debug-graph-output-format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
-
-subparsers = argparser.add_subparsers(dest='cmd', title='Commands')
-subparsers.required = True
-
-parser_test    = subparsers.add_parser('test', help="Launch tests for the whole repo or, if specified, an app or one of its services.")
-parser_build   = subparsers.add_parser('build', help="Launch the build for the whole repo or, if specified, an app or one of its services.")
-parser_run     = subparsers.add_parser('run', help="Launch the application or only one of its services.")
-parser_stop    = subparsers.add_parser('stop', help="Stop the containers lauched with 'dmake run'.")
-parser_shell   = subparsers.add_parser('shell', help="Run a shell session withing a docker container with the environment set up for a given service.")
-parser_deploy  = subparsers.add_parser('deploy', help="Deploy specified apps and services.")
-parser_release = subparsers.add_parser('release', help="Create a release of the app on Github.")
-
-
-# "service" argument
-for parser in [parser_test, parser_deploy]:
-    parser.add_argument("service", nargs='?', default='*', help="Apply command to the full repository or, if specified, to the app/service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
-for parser in [parser_shell]:
-    parser.add_argument("service", nargs='?', default='.', help="Run a shell session withing the docker base image for the given service. You may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
-for parser in [parser_run]:
-    parser.add_argument("service", help="Run an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
-for parser in [parser_build]:
-    parser.add_argument("service", help="Build an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
-
-parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specified command instead of `docker.command` defined in `dmake.yml` (default: `bash`).")
-add_argument([parser_shell, parser_run, parser_test, parser_deploy],
-             "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=True, dest='with_dependencies', action=common.DependenciesBooleanAction,
-             help="These options control if dependencies are run/tested/deployed. By default, the service is run/tested/deployed alongside its dependencies (service and link dependencies), recursively.")
-add_argument([parser_shell, parser_run, parser_deploy, parser_stop], "-b", "--branch", required=False, default=None, help="Overwrite the git branch name used to select the dmake environment")
-
-parser_run.add_argument("--docker-links-volumes-persistence", "--no-docker-links-volumes-persistence", required=False, default=False, dest='with_docker_links_volumes_persistence', action=common.FlagBooleanAction, help="Control persistence of docker-links volumes (default: non-persistent (for dmake run)).")
-
-parser_release.add_argument("app", help="Create the release for the given app.")
-parser_release.add_argument('-t', '--tag', nargs='?', help="The release tag from which the release will be created.")
-
-parser_test.set_defaults(func=core.make)
-parser_run.set_defaults(func=core.make)
-parser_build.set_defaults(func=core.make)
-parser_stop.set_defaults(func=commands.stop.entry_point)
-parser_shell.set_defaults(func=core.make)
-parser_deploy.set_defaults(func=core.make)
-parser_release.set_defaults(func=commands.release.entry_point)
-
-
-# Shell completion
-parser_completion = subparsers.add_parser('completion',
-                                          help="Output shell completion code for bash (may work for zsh)",
-                                          formatter_class=argparse.RawDescriptionHelpFormatter,
-                                          description="""
-This command can generate shell autocompletions. e.g.
-
-    $ dmake completion
-
-Can be sourced as such
-
-    $ source <(dmake completion)
-
-./install.sh should have already installed everything in:
-- ${HOME}/.dmake/completion.bash.inc
-- ${HOME}/.dmake/config.sh
-- ${HOME}/.bashrc
-""",
-                                          )
-parser_completion.add_argument("shell", nargs='?', default='bash', choices=['bash'], help="Shell to emit completion for")
-parser_completion.set_defaults(func=completion_action)
-
-try:
-    # Parse command args
-    argcomplete.autocomplete(argparser, default_completer=None)
-    args = argparser.parse_args()
-    common.init(args)
-    args.func(args)
-except DMakeException as e:
-    print('ERROR: ' + str(e))
-    sys.exit(1)
+        # Parse command args
+        argcomplete.autocomplete(cli.argparser, default_completer=None)
+        args = cli.argparser.parse_args()
+        common.init(args)
+        args.func(args)
+    except DMakeException as e:
+        print('ERROR: ' + str(e))
+        sys.exit(1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E251,E302,E501,E221
+ignore = W503,E251,E302,E501,E221
 
 [tool:pytest]
 addopts = --ignore=./deepomatic/dmake

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,2 @@
+rebuild_graphs:
+	python3 -c "from test_graph import *; generate_resources_graph()"

--- a/test/e2e/dmake.yml
+++ b/test/e2e/dmake.yml
@@ -24,10 +24,16 @@ services:
        link_name: web
        env_exports:
          WEB_URL: http://web:8000
+     - service_name: test-web2
+       link_name: web2
+       env_exports:
+         WEB2_URL: http://web2:8000
      - service_name: test-external-dependency-nginx
        link_name: nginx
        env_exports:
          NGINX_URL: http://nginx/
+     - service_name: test-external-dependency-nginx
+       link_name: nginx2
     config:
       docker_image:
         build:
@@ -45,6 +51,7 @@ services:
         - bash -xc "[[ \"${IMAGE_TAG_PREFIX}\" =~ [a-zA-Z0-9][a-zA-Z0-9_.-]+ ]]"
         - curl -sSf "${NGINX_URL}"
         - curl -sSf "${WEB_URL}/api/factorial/?n=5"
+        - curl -sSf "${WEB2_URL}/api/factorial/?n=5"
         - test -f /dmake.yml
         - rm -rf /artifacts/digest
         - echo "${COMMIT_ID}" > /artifacts/digest

--- a/test/test-resources/graph.build.test-web.gv
+++ b/test/test-resources/graph.build.test-web.gv
@@ -1,0 +1,19 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
+dmake-test/test-web
+None
+height=1"]
+	}
+}

--- a/test/test-resources/graph.deploy.*.gv
+++ b/test/test-resources/graph.deploy.*.gv
@@ -1,0 +1,245 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=2"]
+		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1604::base
+None
+height=0"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
+dmake-test/test-e2e
+None
+height=5"]
+		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
+dmake-test/test-external-dependency-nginx
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-gpu', None)" [label="build_docker
+dmake-test/test-gpu
+None
+height=0"]
+		"('build_docker', 'dmake-test/test-k8s', None)" [label="build_docker
+dmake-test/test-k8s
+None
+height=0"]
+		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
+dmake-test/test-web
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1604
+None
+height=1"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-web', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('test', 'dmake-test/test-e2e', None)"
+	"('deploy', 'dmake-test/test-external-dependency-nginx', None)" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-external-dependency-nginx', None)" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-gpu', None)" -> "('build_docker', 'dmake-test/test-gpu', None)"
+	"('deploy', 'dmake-test/test-gpu', None)" -> "('test', 'dmake-test/test-gpu', None)"
+	"('deploy', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
+	"('deploy', 'dmake-test/test-k8s', None)" -> "('test', 'dmake-test/test-k8s', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('test', 'dmake-test/test-web', None)"
+	"('deploy', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-web2', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('deploy', 'dmake-test/test-web2', None)" -> "('test', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('deploy', 'dmake-test/test-e2e', None)" [label="deploy
+dmake-test/test-e2e
+None
+height=7"]
+		"('deploy', 'dmake-test/test-external-dependency-nginx', None)" [label="deploy
+dmake-test/test-external-dependency-nginx
+None
+height=6"]
+		"('deploy', 'dmake-test/test-gpu', None)" [label="deploy
+dmake-test/test-gpu
+None
+height=2"]
+		"('deploy', 'dmake-test/test-k8s', None)" [label="deploy
+dmake-test/test-k8s
+None
+height=2"]
+		"('deploy', 'dmake-test/test-web', None)" [label="deploy
+dmake-test/test-web
+None
+height=6"]
+		"('deploy', 'dmake-test/test-web2', None)" [label="deploy
+dmake-test/test-web2
+None
+height=6"]
+		"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" [label="deploy
+dmake-test/test-worker:ubuntu-1604
+None
+height=5"]
+		"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" [label="deploy
+dmake-test/test-worker:ubuntu-1804
+None
+height=5"]
+	}
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('test', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('test', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx)
+height=5"]
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx2)
+height=5"]
+		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
+dmake-test/test-web
+test-web (web)
+height=5"]
+		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
+dmake-test/test-web2
+test-web2 (web2)
+height=5"]
+		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1604
+test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))"
+	"('test', 'dmake-test/test-external-dependency-nginx', None)" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('test', 'dmake-test/test-gpu', None)" -> "('build_docker', 'dmake-test/test-gpu', None)"
+	"('test', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('test', 'dmake-test/test-e2e', None)" [label="test
+dmake-test/test-e2e
+None
+height=6"]
+		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
+dmake-test/test-external-dependency-nginx
+None
+height=4"]
+		"('test', 'dmake-test/test-gpu', None)" [label="test
+dmake-test/test-gpu
+None
+height=1"]
+		"('test', 'dmake-test/test-k8s', None)" [label="test
+dmake-test/test-k8s
+None
+height=1"]
+		"('test', 'dmake-test/test-web', None)" [label="test
+dmake-test/test-web
+None
+height=4"]
+		"('test', 'dmake-test/test-web2', None)" [label="test
+dmake-test/test-web2
+None
+height=4"]
+		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
+dmake-test/test-worker:ubuntu-1604
+None
+height=2"]
+		"('test', 'dmake-test/test-worker_ubuntu-1804', None)" [label="test
+dmake-test/test-worker:ubuntu-1804
+None
+height=2"]
+	}
+}

--- a/test/test-resources/graph.deploy.test-e2e.gv
+++ b/test/test-resources/graph.deploy.test-e2e.gv
@@ -1,0 +1,215 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=2"]
+		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1604::base
+None
+height=0"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
+dmake-test/test-e2e
+None
+height=5"]
+		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
+dmake-test/test-external-dependency-nginx
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
+dmake-test/test-web
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1604
+None
+height=1"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-web', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('deploy', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-e2e', None)" -> "('test', 'dmake-test/test-e2e', None)"
+	"('deploy', 'dmake-test/test-external-dependency-nginx', None)" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-external-dependency-nginx', None)" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('deploy', 'dmake-test/test-web', None)" -> "('test', 'dmake-test/test-web', None)"
+	"('deploy', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-web2', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('deploy', 'dmake-test/test-web2', None)" -> "('test', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('deploy', 'dmake-test/test-e2e', None)" [label="deploy
+dmake-test/test-e2e
+None
+height=7"]
+		"('deploy', 'dmake-test/test-external-dependency-nginx', None)" [label="deploy
+dmake-test/test-external-dependency-nginx
+None
+height=6"]
+		"('deploy', 'dmake-test/test-web', None)" [label="deploy
+dmake-test/test-web
+None
+height=6"]
+		"('deploy', 'dmake-test/test-web2', None)" [label="deploy
+dmake-test/test-web2
+None
+height=6"]
+		"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" [label="deploy
+dmake-test/test-worker:ubuntu-1604
+None
+height=5"]
+		"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" [label="deploy
+dmake-test/test-worker:ubuntu-1804
+None
+height=5"]
+	}
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('test', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('test', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx)
+height=5"]
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx2)
+height=5"]
+		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
+dmake-test/test-web
+test-web (web)
+height=5"]
+		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
+dmake-test/test-web2
+test-web2 (web2)
+height=5"]
+		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1604
+test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))"
+	"('test', 'dmake-test/test-external-dependency-nginx', None)" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('test', 'dmake-test/test-e2e', None)" [label="test
+dmake-test/test-e2e
+None
+height=6"]
+		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
+dmake-test/test-external-dependency-nginx
+None
+height=4"]
+		"('test', 'dmake-test/test-web', None)" [label="test
+dmake-test/test-web
+None
+height=4"]
+		"('test', 'dmake-test/test-web2', None)" [label="test
+dmake-test/test-web2
+None
+height=4"]
+		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
+dmake-test/test-worker:ubuntu-1604
+None
+height=2"]
+		"('test', 'dmake-test/test-worker_ubuntu-1804', None)" [label="test
+dmake-test/test-worker:ubuntu-1804
+None
+height=2"]
+	}
+}

--- a/test/test-resources/graph.deploy.test-k8s.gv
+++ b/test/test-resources/graph.deploy.test-k8s.gv
@@ -1,0 +1,28 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-k8s', None)" [label="build_docker
+dmake-test/test-k8s
+None
+height=0"]
+	}
+	"('deploy', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
+	"('deploy', 'dmake-test/test-k8s', None)" -> "('test', 'dmake-test/test-k8s', None)"
+	{
+		rank=same
+		"('deploy', 'dmake-test/test-k8s', None)" [label="deploy
+dmake-test/test-k8s
+None
+height=2"]
+	}
+	"('test', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
+	{
+		rank=same
+		"('test', 'dmake-test/test-k8s', None)" [label="test
+dmake-test/test-k8s
+None
+height=1"]
+	}
+}

--- a/test/test-resources/graph.run.test-e2e.gv
+++ b/test/test-resources/graph.run.test-e2e.gv
@@ -1,0 +1,123 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=1"]
+		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1604::base
+None
+height=0"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
+dmake-test/test-e2e
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
+dmake-test/test-external-dependency-nginx
+None
+height=2"]
+		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
+dmake-test/test-web
+None
+height=2"]
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=2"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1604
+None
+height=1"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('run', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('run', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
+	"('run', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))"
+	"('run', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))"
+	"('run', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-e2e', None)" [label="run
+dmake-test/test-e2e
+None
+height=4"]
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx)
+height=3"]
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx2)
+height=3"]
+		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
+dmake-test/test-web
+test-web (web)
+height=3"]
+		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
+dmake-test/test-web2
+test-web2 (web2)
+height=3"]
+		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1604
+test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
+height=2"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=2"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+}

--- a/test/test-resources/graph.run.test-web2.gv
+++ b/test/test-resources/graph.run.test-web2.gv
@@ -1,0 +1,65 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=1"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=2"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('run', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-web2', None)" [label="run
+dmake-test/test-web2
+None
+height=3"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=2"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+}

--- a/test/test-resources/graph.shell.test-web.gv
+++ b/test/test-resources/graph.shell.test-web.gv
@@ -1,0 +1,82 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=2"]
+		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1604::base
+None
+height=0"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1604
+None
+height=1"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1604
+test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
+height=2"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=2"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+	"('shell', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('shell', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('shell', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('shell', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('shell', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('shell', 'dmake-test/test-web', None)" [label="shell
+dmake-test/test-web
+None
+height=3"]
+	}
+}

--- a/test/test-resources/graph.test.*.gv
+++ b/test/test-resources/graph.test.*.gv
@@ -1,0 +1,187 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=2"]
+		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1604::base
+None
+height=0"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
+dmake-test/test-e2e
+None
+height=5"]
+		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
+dmake-test/test-external-dependency-nginx
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-gpu', None)" [label="build_docker
+dmake-test/test-gpu
+None
+height=0"]
+		"('build_docker', 'dmake-test/test-k8s', None)" [label="build_docker
+dmake-test/test-k8s
+None
+height=0"]
+		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
+dmake-test/test-web
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1604
+None
+height=1"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('test', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('test', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx)
+height=5"]
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx2)
+height=5"]
+		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
+dmake-test/test-web
+test-web (web)
+height=5"]
+		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
+dmake-test/test-web2
+test-web2 (web2)
+height=5"]
+		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1604
+test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))"
+	"('test', 'dmake-test/test-external-dependency-nginx', None)" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('test', 'dmake-test/test-gpu', None)" -> "('build_docker', 'dmake-test/test-gpu', None)"
+	"('test', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('test', 'dmake-test/test-e2e', None)" [label="test
+dmake-test/test-e2e
+None
+height=6"]
+		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
+dmake-test/test-external-dependency-nginx
+None
+height=4"]
+		"('test', 'dmake-test/test-gpu', None)" [label="test
+dmake-test/test-gpu
+None
+height=1"]
+		"('test', 'dmake-test/test-k8s', None)" [label="test
+dmake-test/test-k8s
+None
+height=1"]
+		"('test', 'dmake-test/test-web', None)" [label="test
+dmake-test/test-web
+None
+height=4"]
+		"('test', 'dmake-test/test-web2', None)" [label="test
+dmake-test/test-web2
+None
+height=4"]
+		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
+dmake-test/test-worker:ubuntu-1604
+None
+height=2"]
+		"('test', 'dmake-test/test-worker_ubuntu-1804', None)" [label="test
+dmake-test/test-worker:ubuntu-1804
+None
+height=2"]
+	}
+}

--- a/test/test-resources/graph.test.test-e2e.gv
+++ b/test/test-resources/graph.test.test-e2e.gv
@@ -1,0 +1,169 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=2"]
+		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1604::base
+None
+height=0"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
+dmake-test/test-e2e
+None
+height=5"]
+		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
+dmake-test/test-external-dependency-nginx
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
+dmake-test/test-web
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1604
+None
+height=1"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" -> "('test', 'dmake-test/test-web', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" -> "('test', 'dmake-test/test-web2', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx)
+height=5"]
+		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
+dmake-test/test-external-dependency-nginx
+test-external-dependency-nginx (nginx2)
+height=5"]
+		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
+dmake-test/test-web
+test-web (web)
+height=5"]
+		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
+dmake-test/test-web2
+test-web2 (web2)
+height=5"]
+		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1604
+test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))"
+	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))"
+	"('test', 'dmake-test/test-external-dependency-nginx', None)" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('build_docker', 'dmake-test/test-web', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('test', 'dmake-test/test-e2e', None)" [label="test
+dmake-test/test-e2e
+None
+height=6"]
+		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
+dmake-test/test-external-dependency-nginx
+None
+height=4"]
+		"('test', 'dmake-test/test-web', None)" [label="test
+dmake-test/test-web
+None
+height=4"]
+		"('test', 'dmake-test/test-web2', None)" [label="test
+dmake-test/test-web2
+None
+height=4"]
+		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
+dmake-test/test-worker:ubuntu-1604
+None
+height=2"]
+		"('test', 'dmake-test/test-worker_ubuntu-1804', None)" [label="test
+dmake-test/test-worker:ubuntu-1804
+None
+height=2"]
+	}
+}

--- a/test/test-resources/graph.test.test-web2.gv
+++ b/test/test-resources/graph.test.test-web2.gv
@@ -1,0 +1,77 @@
+// DMake Services
+digraph {
+	node [shape=box]
+	{
+		rank=same
+		"('base', 'dmake-test-web-base__base', None)" [label="base
+dmake-test-web-base::base
+None
+height=2"]
+		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
+dmake-test-worker-base:ubuntu-1804::base
+None
+height=0"]
+	}
+	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
+	{
+		rank=same
+		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
+dmake-test/test-web2
+None
+height=3"]
+		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
+dmake-test/test-worker:ubuntu-1804
+None
+height=1"]
+	}
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
+	{
+		rank=same
+		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
+dmake-test/test-worker:ubuntu-1804
+test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
+height=3"]
+	}
+	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	{
+		rank=same
+		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
+links/dmake-test/rabbitmq
+None
+height=1"]
+	}
+	{
+		rank=same
+		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
+shared_rabbitmq_var_lib::shared_volume
+None
+height=0"]
+		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
+shared_volume_web_and_workers::shared_volume
+None
+height=1"]
+	}
+	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
+	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
+	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
+	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
+	{
+		rank=same
+		"('test', 'dmake-test/test-web2', None)" [label="test
+dmake-test/test-web2
+None
+height=4"]
+		"('test', 'dmake-test/test-worker_ubuntu-1804', None)" [label="test
+dmake-test/test-worker:ubuntu-1804
+None
+height=2"]
+	}
+}

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+
+import pytest
+
+from dmake import cli, common, core, deepobuild
+
+graph_test_list = [
+    ('shell', 'test-web'),
+    ('build', 'test-web'),
+    ('test', 'test-e2e'),
+    ('test', 'test-web2'),
+    ('test', '*'),
+    ('run', 'test-web2'),
+    ('run', 'test-e2e'),
+    ('deploy', 'test-k8s'),
+    ('deploy', 'test-e2e'),
+    ('deploy', '*'),
+]
+def generate_resources_graph(test_list = graph_test_list):
+    path = os.path.dirname(__file__)
+    for command, service in test_list:
+        expected_dot_path = os.path.join(path, 'test-resources/graph.{command}.{service}.gv'.format(command=command, service=service))
+        subprocess.call([
+            'dmake',
+            '--debug-graph-and-exit',
+            '--debug-graph-output-filename={}'.format(expected_dot_path),
+            command, service
+        ], cwd=path)
+
+@pytest.mark.parametrize("command,service", graph_test_list)
+def test_graph(command, service):
+    deepobuild.reset()
+
+    args = cli.argparser.parse_args([command, service])
+    common.init(args)
+
+    common.sub_dir = 'test'  # to test '*' for only 'test/'
+    common.generate_dot_graph = True
+    common.exit_after_generate_dot_graph = True
+    common.dot_graph_filename = None
+    dot = core.make(args)
+
+    path = os.path.dirname(__file__)
+    expected_dot_path = os.path.join(path, 'test-resources/graph.{command}.{service}.gv'.format(command=command, service=service))
+    with open(expected_dot_path, "r") as f:
+        # dot.source and dot.render() to file differ with extra '\n'
+        expected_dot_source = f.read().rstrip('\n')
+
+    assert expected_dot_source == dot.source, (
+        "Unexpected `dmake {command} {service}` graph."
+        "Update it with:"
+        "\npushd '{path}' && dmake --debug-graph-and-exit --debug-graph-output-filename='{expected_dot_path}' {command} '{service}' && popd"
+        "\nOr rebuild them all:"
+        "\nmake -C {path} rebuild_graphs".format(path=path, command=command, service=service, expected_dot_path=expected_dot_path)
+    )

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -85,6 +85,11 @@ services:
       cobertura_report: coverage.xml
 
   - service_name: test-web2
+    needed_services:
+      - service_name: test-worker:ubuntu-1804
+        link_name: worker-ubuntu-1804
+        env:
+          TEST_SHARED_VOLUME: 1
     needed_links:
       - rabbitmq
     config:


### PR DESCRIPTION
Test several dmake commands, and compare expected internal graph (via
the `--debug-graph` feature).

DMake generates an internal graph planning the various steps to
execute, according to the command-line and the dmake.yml files.

Example:
service foo with needed_service bar, `dmake test foo` execution plan
graph would have the following edges:
- test foo -> build foo
- test foo -> run bar
- build foo -> build-base foo
- run bar -> test bar
- run bar -> build bar
- test bar -> build bar
- build bar -> build-base bar

This graph can be explored with `dmake --debug-graph` options.

To make execution plan construction easier when adding features to
DMake, this PR adds tests comparing expected with actual execution
plan graph dumps.

The reference graphs can be generated with:
```
make -C test rebuild_graphs
```

Required some cleanup:
- split `argparser` construction out of `dmake` and into `cli.py` to
  be importable
- introduce deepbuild.reset() to reset static classes
  states (just SharedVolumes for now)
- stabilize graph dump order: both ordered dump and ordered
  NeededServiceSerializer env* str/repr.

Also:
- less sys.exit()
- more verbose pytest output to show full diffs on error
- fix/improve test/ project, notably add 2 needed_services on same
  service, but different specialization, to test an edge case on
  NeededServiceSerializer sort.