### PR TITLE
Auto detect changed directories and services with '+' as service name

### DIFF
--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -54,14 +54,16 @@ parser_release = subparsers.add_parser('release', help="Create a release of the 
 
 
 # "service" argument
-for parser in [parser_test, parser_deploy]:
+for parser in [parser_deploy]:
     parser.add_argument("service", nargs='?', default='*', help="Apply command to the full repository or, if specified, to the app/service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
+for parser in [parser_test]:
+    parser.add_argument("service", nargs='?', default='*', help="Apply command to the full repository (`*`) or to changed services (`+`), or the specified app/service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
 for parser in [parser_shell]:
     parser.add_argument("service", nargs='?', default='.', help="Run a shell session withing the docker base image for the given service. You may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
 for parser in [parser_run]:
     parser.add_argument("service", help="Run an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
 for parser in [parser_build]:
-    parser.add_argument("service", help="Build an application or a service. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
+    parser.add_argument("service", help="Build an application or a service. Use `+` to build only changed services. When specifying a service, you may skip the app if there is no ambiguity, otherwise, you need to specify 'app/service'.").completer = core.service_completer
 
 parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specified command instead of `docker.command` defined in `dmake.yml` (default: `bash`).")
 add_argument([parser_shell, parser_run, parser_test, parser_deploy],

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -424,28 +424,26 @@ def init(_options, early_exit=False):
     # Currently set if any dmake file describes a deploy stage matching current branch; updated after files parsing
     is_release_branch = None
 
-    use_pipeline = True
     # For PRs on Jenkins this will give the source branch name
     branch = os.getenv('CHANGE_BRANCH', None)
-    # When not PR, this will be the actual branch name
     if branch is None:
+        # When on Jenkins but not PR, this will be the actual branch name
         branch = os.getenv('BRANCH_NAME', None)
     if branch is None:
+        # Not on Jenkins: bash mode: do not emit jenkins pipeline script
+        branch = run_shell_command("git rev-parse --abbrev-ref HEAD")
         use_pipeline = False
-        target = os.getenv('ghprbTargetBranch', None)
-        pr_id  = os.getenv('ghprbPullId', None)
+        target = None
+        pr_id  = None
         build_id = os.getenv('BUILD_NUMBER', '0')
-        if target is None:
-            branch = os.getenv('GIT_BRANCH')
-        else:
-            branch = "PR-%s" % pr_id
-        if branch is None:
-            branch = run_shell_command("git rev-parse --abbrev-ref HEAD")
+        is_pr = False
     else:
+        # On Jenkins, assume multibranch project
+        use_pipeline = True
         target   = os.getenv('CHANGE_TARGET', None)
         pr_id    = os.getenv('CHANGE_ID')
         build_id = os.getenv('BUILD_ID', '0')
-    is_pr = target is not None
+        is_pr = target is not None
     force_full_deploy = False
 
     if 'branch' in options and options.branch:

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -433,7 +433,7 @@ def init(_options, early_exit=False):
         # Not on Jenkins: bash mode: do not emit jenkins pipeline script
         branch = run_shell_command("git rev-parse --abbrev-ref HEAD")
         use_pipeline = False
-        target = None
+        target = os.getenv('CHANGE_TARGET', '@{upstream}')
         pr_id  = None
         build_id = os.getenv('BUILD_NUMBER', '0')
         is_pr = False

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -29,7 +29,8 @@ def find_symlinked_directories():
 def look_for_changed_directories():
     if common.force_full_deploy:
         return None
-    if common.target is None:
+
+    if not common.target:
         tag = get_tag_name()
         common.logger.info("Looking for changes between HEAD and %s" % tag)
         git_ref = "%s...HEAD" % tag
@@ -40,13 +41,13 @@ def look_for_changed_directories():
             common.logger.debug("Fetching tag {} failed: {}".format(tag, e))
             common.logger.info("Tag {} not found on remote, assuming everything changed.")
             return None
-
-    elif common.target == '@{upstream}':
-        common.logger.info("Looking for changes with @{upstream}")
-        git_ref = '@{upstream}'
     else:
-        common.logger.info("Looking for changes between HEAD and %s" % common.target)
-        git_ref = "%s/%s...HEAD" % (common.remote, common.target)
+        if common.is_local:
+            common.logger.info("Looking for changes with {}".format(common.target))
+            git_ref = common.target
+        else:
+            common.logger.info("Looking for changes between HEAD and %s" % common.target)
+            git_ref = "%s/%s...HEAD" % (common.remote, common.target)
 
     try:
         output = common.run_shell_command("git diff --name-only %s" % git_ref)

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -33,6 +33,9 @@ def look_for_changed_directories():
         tag = get_tag_name()
         common.logger.info("Looking for changes between HEAD and %s" % tag)
         git_ref = "%s...HEAD" % tag
+    elif common.target == '@{upstream}':
+        common.logger.info("Looking for changes with @{upstream}")
+        git_ref = '@{upstream}'
     else:
         common.logger.info("Looking for changes between HEAD and %s" % common.target)
         git_ref = "%s/%s...HEAD" % (common.remote, common.target)
@@ -641,8 +644,12 @@ def make(options, parse_files_only=False):
     auto_complete = False
     auto_completed_app = None
     if app == "*":
+        # all services
         app = None
         common.force_full_deploy = True
+    elif app == "+":
+        # changed services only
+        pass
     elif app is not None:
         n = len(app.split('/'))
         if n > 2:

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -33,6 +33,14 @@ def look_for_changed_directories():
         tag = get_tag_name()
         common.logger.info("Looking for changes between HEAD and %s" % tag)
         git_ref = "%s...HEAD" % tag
+
+        try:
+            common.run_shell_command2("git fetch origin +refs/tags/{tag}:refs/tags/{tag}".format(tag=tag))
+        except common.ShellError as e:
+            common.logger.debug("Fetching tag {} failed: {}".format(tag, e))
+            common.logger.info("Tag {} not found on remote, assuming everything changed.")
+            return None
+
     elif common.target == '@{upstream}':
         common.logger.info("Looking for changes with @{upstream}")
         git_ref = '@{upstream}'

--- a/dmake/docker_image.py
+++ b/dmake/docker_image.py
@@ -45,6 +45,10 @@ class AbstractDockerImage(SerializerMixin):
         pass
 
     @abstractmethod
+    def get_source_directories_additional_contexts(self):
+        pass
+
+    @abstractmethod
     def is_runnable(self):
         pass
 
@@ -74,6 +78,10 @@ class ExternalDockerImage(AbstractDockerImage):
         """No variant for external image"""
         return None
 
+    def get_source_directories_additional_contexts(self):
+        """No additional source context supported"""
+        return []
+
     def is_runnable(self):
         return True
 
@@ -92,8 +100,12 @@ class ExternalDockerImage(AbstractDockerImage):
 class ServiceDockerCommonSerializer(YAML2PipelineSerializer, AbstractDockerImage):
     name             = FieldSerializer("string", optional = True, help_text = "Name of the docker image to build. By default it will be {:app_name}-{:service_name}. If there is no docker user, it won be pushed to the registry. You can use environment variables.")
     base_image_variant = FieldSerializer(["string", "array"], optional = True, child = "string", help_text = "Specify which `base_image` variants are used as `base_image` for this service. Array: multi-variant service. Default: first 'docker.base_image'.")
+    source_directories_additional_contexts = FieldSerializer("array", child = "string", default = [], example = ['../web'], help_text = "NOT RECOMMENDED. Additional source directories contexts for changed services auto detection in case of build context going outside of the dmake.yml directory.")
     check_private    = FieldSerializer("bool", default = True, help_text = "Check that the docker repository is private before pushing the image.")
     tag              = FieldSerializer("string", optional = True, help_text = "Tag of the docker image to build. By default it will be '[{:variant}-]{:branch_name}-{:build_id}', sanitized and made unique with a hash suffix if needed")
+
+    def get_source_directories_additional_contexts(self):
+        return self.source_directories_additional_contexts
 
     def get_image_name(self, env=None, latest=False):
         if env is None:

--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -1,0 +1,11 @@
+# this is used by worker/ (its docker build context is `../`) , which uses worker/ and web/ only
+*
+!worker/
+!web/
+
+# worker/ ignores
+worker/dmake.yml
+worker/.dmake/
+worker/.dockerignore
+worker/deploy/Dockerfile
+worker/bin/

--- a/test/test-resources/graph.deploy.*.gv
+++ b/test/test-resources/graph.deploy.*.gv
@@ -18,6 +18,7 @@ height=0"]
 	}
 	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker2', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
 	{
@@ -46,6 +47,10 @@ height=3"]
 dmake-test/test-web2
 None
 height=3"]
+		"('build_docker', 'dmake-test/test-worker2', None)" [label="build_docker
+dmake-test/test-worker2
+None
+height=1"]
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1604
 None
@@ -74,6 +79,8 @@ height=1"]
 	"('deploy', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
 	"('deploy', 'dmake-test/test-web2', None)" -> "('deploy', 'dmake-test/test-worker_ubuntu-1804', None)"
 	"('deploy', 'dmake-test/test-web2', None)" -> "('test', 'dmake-test/test-web2', None)"
+	"('deploy', 'dmake-test/test-worker2', None)" -> "('build_docker', 'dmake-test/test-worker2', None)"
+	"('deploy', 'dmake-test/test-worker2', None)" -> "('test', 'dmake-test/test-worker2', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
@@ -104,6 +111,10 @@ height=6"]
 dmake-test/test-web2
 None
 height=6"]
+		"('deploy', 'dmake-test/test-worker2', None)" [label="deploy
+dmake-test/test-worker2
+None
+height=3"]
 		"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" [label="deploy
 dmake-test/test-worker:ubuntu-1604
 None
@@ -199,6 +210,7 @@ height=1"]
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker2', None)" -> "('build_docker', 'dmake-test/test-worker2', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
@@ -233,6 +245,10 @@ height=4"]
 dmake-test/test-web2
 None
 height=4"]
+		"('test', 'dmake-test/test-worker2', None)" [label="test
+dmake-test/test-worker2
+None
+height=2"]
 		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
 dmake-test/test-worker:ubuntu-1604
 None

--- a/test/test-resources/graph.test.*.gv
+++ b/test/test-resources/graph.test.*.gv
@@ -18,6 +18,7 @@ height=0"]
 	}
 	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
+	"('build_docker', 'dmake-test/test-worker2', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
 	{
@@ -46,6 +47,10 @@ height=3"]
 dmake-test/test-web2
 None
 height=3"]
+		"('build_docker', 'dmake-test/test-worker2', None)" [label="build_docker
+dmake-test/test-worker2
+None
+height=1"]
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1604
 None
@@ -141,6 +146,7 @@ height=1"]
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
+	"('test', 'dmake-test/test-worker2', None)" -> "('build_docker', 'dmake-test/test-worker2', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
@@ -175,6 +181,10 @@ height=4"]
 dmake-test/test-web2
 None
 height=4"]
+		"('test', 'dmake-test/test-worker2', None)" [label="test
+dmake-test/test-worker2
+None
+height=2"]
 		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
 dmake-test/test-worker:ubuntu-1604
 None

--- a/test/worker/Dockerfile
+++ b/test/worker/Dockerfile
@@ -4,7 +4,8 @@ FROM ${BASE_IMAGE} as builder
 ARG WORKDIR
 WORKDIR ${WORKDIR}
 
-COPY . .
+COPY ./worker .
+COPY ./web /web
 
 RUN make -j$(nproc) install prefix=/usr/local/worker
 ARG BUILD_HOSTNAME
@@ -16,6 +17,7 @@ FROM ${BASE_IMAGE} as runtime
 WORKDIR /app/test/worker
 
 COPY --from=builder /usr/local/worker .
+COPY --from=builder /web/requirements.txt /web-requirements.txt
 
 CMD ["deploy/start.sh"]
 ENTRYPOINT ["/app/test/worker/deploy/entrypoint.sh"]

--- a/test/worker/deploy/start.sh
+++ b/test/worker/deploy/start.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+echo "Verify build context: get file from web"
+cat /web-requirements.txt
+
 if [ "${TEST_SHARED_VOLUME}" -eq 1 ]; then
   echo "Write file for volume test"
   echo "hello from worker: ${HOSTNAME}" >> /shared_volume/hello-from-worker.${HOSTNAME}

--- a/test/worker/dmake.yml
+++ b/test/worker/dmake.yml
@@ -38,6 +38,12 @@ docker_links:
       RABBITMQ_DEFAULT_PASS: password
 
 services:
+  - service_name: test-worker2
+    config:
+      docker_image: ubuntu:18.04
+    tests:
+      commands:
+        - echo 'OK'
   - service_name: test-worker
     needed_links:
       - rabbitmq
@@ -49,10 +55,9 @@ services:
         base_image_variant:
           - ubuntu-1604
           - ubuntu-1804
-        # short form: `build: .`
         build:
-          context: .
-          dockerfile: Dockerfile
+          context: ../  # limited to worker/ and web/, see ../.dockerignore
+          dockerfile: worker/Dockerfile
           args:
             BUILD_HOSTNAME: ${HOSTNAME}
           labels:

--- a/test/worker/dmake.yml
+++ b/test/worker/dmake.yml
@@ -55,6 +55,8 @@ services:
         base_image_variant:
           - ubuntu-1604
           - ubuntu-1804
+        source_directories_additional_contexts:
+          - ../web
         build:
           context: ../  # limited to worker/ and web/, see ../.dockerignore
           dockerfile: worker/Dockerfile


### PR DESCRIPTION
MVP for #425

## Features
- Auto detect changed directories and services with `+` as service name
  Also, work locally with default CHANGE_TARGET=@{upstream}.
- Change detection: only use origin/ in non-local mode
  This allows easy CHANGE_TARGET override locally:
  - CHANGE_TARGET=HEAD dmake test +
  - CHANGE_TARGET=master dmake test +
  - CHANGE_TARGET='' dmake deploy +  # uses deployed_version_{branch}
  tag as in jenkins
- Support build.context: ../ with `+` change detection: manually declare additional contexts
  Add `service.config.docker_image.source_directories_additional_contexts list
- extended build/source context: only activate concerned service, not the whole dmake.yml
- For jenkins non-PR builds change detection we need to fetch tags

## Cleanup
- Cleanup branch/change detection
  ghprb* env vars were unused (pre-multibranch jenkins projects)
- Cleanup look_for_changed_directories() and some more logs

## Tests
- Add parent directory test for docker build context

## TODO later
- [ ] #149 more optimal support of submodule changes
- [ ] #426 detects too much changes on directory names prefixes conflicts
- [ ] #427 do not test dependencies recursively