### PR TITLE
Allow faster unit-tests without dependencies at test-time

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -194,10 +194,11 @@ def activate_link(loaded_files, service_providers, service_dependencies, service
 
 ###############################################################################
 
-def activate_needed_services(loaded_files, service_providers, service_dependencies, needs, command):
+def activate_needed_services(loaded_files, service_providers, service_dependencies, needs, command, needed_for):
     children = []
     for service, service_customization in needs:
-        children += activate_service(loaded_files, service_providers, service_dependencies, command, service, service_customization)
+        if service_customization is None or service_customization.needed_for.kind(needed_for):
+            children += activate_service(loaded_files, service_providers, service_dependencies, command, service, service_customization)
     return children
 
 ###############################################################################
@@ -215,14 +216,14 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
         if command == 'shell':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
             if common.options.with_dependencies and needs is not None:
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, command='run', needed_for='run')
             if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
             children += activate_base(base_variant)
         elif command == 'test':
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
             if common.options.with_dependencies and needs is not None:
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, command='run', needed_for='test')
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
@@ -234,7 +235,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
                 children += activate_service(loaded_files, service_providers, service_dependencies, 'test', service)
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if common.options.with_dependencies and needs is not None:
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, command='run', needed_for='run')
             if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
         elif command == 'run_link':
@@ -247,7 +248,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
                 # but we don't want to create extra deployments because of customization
                 # => deploy recursively using needs dependency, but ignore service customization
                 uncustomized_needs = [(child_service, None) for child_service, child_service_customization in needs]
-                children += activate_needed_services(loaded_files, service_providers, service_dependencies, uncustomized_needs, 'deploy')
+                children += activate_needed_services(loaded_files, service_providers, service_dependencies, uncustomized_needs, command='deploy', needed_for='fake__not_used')
 
         else:
             raise Exception("Unknown command '%s'" % command)

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -216,6 +216,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
             children += activate_service_shared_volumes(loaded_files, service_providers, service)
             if common.options.with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
+            if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
             children += activate_base(base_variant)
         elif command == 'test':
@@ -234,6 +235,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
             children += activate_service(loaded_files, service_providers, service_dependencies, 'build_docker', service)
             if common.options.with_dependencies and needs is not None:
                 children += activate_needed_services(loaded_files, service_providers, service_dependencies, needs, 'run')
+            if common.options.with_dependencies:
                 children += activate_link(loaded_files, service_providers, service_dependencies, service)
         elif command == 'run_link':
             children += activate_link_shared_volumes(loaded_files, service_providers, service)

--- a/test/test-resources/graph.deploy.*.gv
+++ b/test/test-resources/graph.deploy.*.gv
@@ -208,7 +208,6 @@ height=1"]
 	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
-	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker2', None)" -> "('build_docker', 'dmake-test/test-worker2', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"

--- a/test/test-resources/graph.deploy.test-e2e.gv
+++ b/test/test-resources/graph.deploy.test-e2e.gv
@@ -175,7 +175,6 @@ height=1"]
 	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
-	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"

--- a/test/test-resources/graph.test.*.gv
+++ b/test/test-resources/graph.test.*.gv
@@ -144,7 +144,6 @@ height=1"]
 	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
-	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker2', None)" -> "('build_docker', 'dmake-test/test-worker2', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"

--- a/test/test-resources/graph.test.test-e2e.gv
+++ b/test/test-resources/graph.test.test-e2e.gv
@@ -129,7 +129,6 @@ height=1"]
 	"('test', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
-	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"

--- a/test/test-resources/graph.test.test-web2.gv
+++ b/test/test-resources/graph.test.test-web2.gv
@@ -6,36 +6,15 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=2"]
-		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
-dmake-test-worker-base:ubuntu-1804::base
-None
 height=0"]
 	}
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
-	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
 	{
 		rank=same
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=3"]
-		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
-dmake-test/test-worker:ubuntu-1804
-None
 height=1"]
-	}
-	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
-	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
-	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
-		rank=same
-		"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
-dmake-test/test-worker:ubuntu-1804
-test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- env_exports: []
-height=3"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	{
@@ -51,26 +30,13 @@ height=1"]
 shared_rabbitmq_var_lib::shared_volume
 None
 height=0"]
-		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
-shared_volume_web_and_workers::shared_volume
-None
-height=1"]
 	}
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
-	"('test', 'dmake-test/test-web2', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
-	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
-	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
-	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	{
 		rank=same
 		"('test', 'dmake-test/test-web2', None)" [label="test
 dmake-test/test-web2
-None
-height=4"]
-		"('test', 'dmake-test/test-worker_ubuntu-1804', None)" [label="test
-dmake-test/test-worker:ubuntu-1804
 None
 height=2"]
 	}

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -90,6 +90,8 @@ services:
         link_name: worker-ubuntu-1804
         env:
           TEST_SHARED_VOLUME: 1
+        needed_for:
+          test: false
     needed_links:
       - rabbitmq
     config:


### PR DESCRIPTION
related on #223

Fine-grained control of needed_services usage: for parent run, for parent test.

# Allow faster unit-tests without dependencies at test-time.

Later: For fully independent unit-tests we would need to also control
needed_links; possibly by merging needed_links into needed_services.
In the meantime it's fine as needed_links do not recursively depend on
anything.

When working on a specific service (or on services found via change
detection), the `test` step previously always started (recursively)
the needed_services (and also started the links services): dmake
assumed they were integration tests.

Now we can individually disable starting each needed_services: for
run, and test.

Example:
```yaml
services:
- service_name: foo
  needed_services:
  - service_name: bar
    needed_for:
      run: true   # foo needs bar to run
      test: true  # foo needs bar to execute its tests
```

Tests:
- `dmake test test-web2` should not start test-worker anymore (but
  still start rabbitmq)
- `dmake run test-web2` should still start test-worker and rabbitmq
- `dmake test test-e2e` should start rabbitmq and test-worker, but
  test-worker should not be started and linked to test `test-web2`
  itself anymore.

# Also
Internal graph dependency bugfix: we didn't properly support services with needed links but no needed services.