### PR TITLE
Change detection mode: test parent dependencies

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -372,6 +372,7 @@ def init(_options, early_exit=False):
     global do_pull_config_dir
     global use_host_ports
     global session_id
+    global change_detection
 
     options = _options
     command = _options.cmd
@@ -386,6 +387,8 @@ def init(_options, early_exit=False):
     exit_after_generate_dot_graph = options.debug_graph_and_exit
     dot_graph_filename = options.debug_graph_output_filename
     dot_graph_format = options.debug_graph_output_format
+
+    change_detection = False  # set in core.make()
 
     try:
         root_dir, sub_dir = find_repo_root()

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1019,6 +1019,7 @@ allowed_link_name_pattern = re.compile("^[a-z0-9-]{1,63}$")  # too laxist, but e
 class NeededForSerializer(YAML2PipelineSerializer):
     run            = FieldSerializer("bool", default = True, help_text = "Parent service `run` needs this dependency service.")
     test           = FieldSerializer("bool", default = True, help_text = "Parent service `test` needs this dependency service.")
+    trigger_test   = FieldSerializer("bool", default = True, help_text = "Parent service `test` is triggered by this dependency service change.")
 
     def kind(self, kind):
         return getattr(self, kind)


### PR DESCRIPTION
MVP for #424

When in change detection mode, we work on all changed services, and test their parent recursively.

Doesn't change anything for other steps than `test`. Notable `dmake deploy +` will still only deploy changed services, not its tested parents.

Can be overridden with `needed_services[].needed_for.trigger_test` boolean.

## TODO later
- [ ] maybe don't recurse in the parents?
- [ ] probably down recurse down from the triggered parents.