### PR TITLE
Better yaml values usage: warn about unexpected use-cases

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1160,7 +1160,7 @@ class BuildSerializer(YAML2PipelineSerializer):
 
 
 class DMakeFileSerializer(YAML2PipelineSerializer):
-    dmake_version      = FieldSerializer("string", help_text = "The dmake version.", example = "0.1")
+    dmake_version      = FieldSerializer(["number", "string"], help_text = "The dmake version.", example = "0.1")
     app_name           = FieldSerializer("string", help_text = "The application name.", example = "my_app", no_slash_no_space = True)
     blocklist          = FieldSerializer("array", child = "file", default = [], help_text = "List of dmake files to ignore", child_path_only = True, example = ['some/sub/dmake.yml'])
     blacklist          = FieldSerializer("array", child = "file", default = [], help_text = "Deprecated. Prefer use of 'blocklist'", child_path_only = True, example = ['some/sub/dmake.yml'])

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -7,7 +7,7 @@ import importlib
 import re
 import requests.exceptions
 from string import Template
-from dmake.serializer import ValidationError, FieldSerializer, YAML2PipelineSerializer
+from dmake.serializer import ValidationError, FieldSerializer, YAML2PipelineSerializer, SerializerType
 import dmake.common as common
 from dmake.common import DMakeException, SharedVolumeNotFoundException, append_command
 import dmake.kubernetes as k8s_utils
@@ -971,7 +971,7 @@ class TestSerializer(YAML2PipelineSerializer):
     docker_links_names = FieldSerializer(deprecated="Use 'services:needed_links' instead", data_type="array", child = "string", migration='0001_docker_links_names_to_needed_links', default = [], example = ['mongo'], help_text = "The docker links names to bind to for this test. Must be declared at the root level of some dmake file of the app.")
     data_volumes       = FieldSerializer("array", child = DataVolumeSerializer(), default = [], help_text = "The read only data volumes to mount. Only S3 is supported for now.")
     commands           = FieldSerializer("array", child = "string", example = ["python manage.py test"], help_text = "The commands to run for integration tests.")
-    timeout            = FieldSerializer("string", optional = True, example = "600", help_text = "The timeout (in seconds) to apply to the tests execution (excluding dependencies, setup, and potential resources locks).")
+    timeout            = FieldSerializer(["number", SerializerType("string", deprecated=True)], optional = True, example = "600", help_text = "The timeout (in seconds) to apply to the tests execution (excluding dependencies, setup, and potential resources locks).")
     junit_report       = FieldSerializer(["string", "array"], child = "string", default = [], post_validation = lambda x: [x] if common.is_string(x) else x, example = "test-reports/nosetests.xml", help_text = "Filepath or array of file paths of xml xunit test reports. Publish a XUnit test report.")
     cobertura_report   = FieldSerializer(["string", "array"], child = "string", default = [], post_validation = lambda x: [x] if common.is_string(x) else x, example = "test-reports/coverage.xml", help_text = "Filepath or array of file paths of xml xunit test reports. Publish a Cobertura report.")
     html_report        = HTMLReportSerializer(optional = True, help_text = "Publish an HTML report.")

--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -1,6 +1,7 @@
 import os, sys
 import copy
 from collections import OrderedDict
+from numbers import Number
 from dmake.common import DMakeException
 import dmake.common as common
 
@@ -37,7 +38,7 @@ class FieldSerializer(object):
             example=None,
             deprecated=None,
             migration=None):
-        self.allowed_types = ["bool", "int", "path", "file", "dir", "string", "array", "dict"]
+        self.allowed_types = ["bool", "int", "number", "path", "file", "dir", "string", "array", "dict"]
 
         if not isinstance(data_type, list):
             data_type = [data_type]
@@ -126,6 +127,10 @@ class FieldSerializer(object):
         elif data_type == "int":
             if not isinstance(data, int):
                 raise WrongType("Expecting int")
+            return data
+        elif data_type == "number":
+            if not isinstance(data, Number) or isinstance(data, bool):
+                raise WrongType("Expecting number")
             return data
         elif data_type == "string":
             if isinstance(data, int) or isinstance(data, float):

--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -151,6 +151,8 @@ class FieldSerializer(object):
         elif data_type == "int":
             if not isinstance(data, int):
                 raise WrongType("Expecting int")
+            if isinstance(data, bool):
+                common.logger.warning("[DEPRECATION WARNING] D004: Field '{field}' in '{file}' should contain an int, it currently contains a bool: {value}.".format(field=field_name, file=file, value=data))
             return data
         elif data_type == "number":
             if not isinstance(data, Number) or isinstance(data, bool):

--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -134,6 +134,7 @@ class FieldSerializer(object):
             return data
         elif data_type == "string":
             if isinstance(data, int) or isinstance(data, float):
+                common.logger.warning("[DEPRECATION WARNING] D002: Field '{field}' in '{file}' should contain a string, it currently contains a {type}: {value}. Add quotes arount the value.".format(field=field_name, file=file, type=type(data), value=data))
                 data = str(data)
             if not common.is_string(data):
                 raise WrongType("Expecting string")

--- a/dmake/serializer.py
+++ b/dmake/serializer.py
@@ -81,7 +81,7 @@ class FieldSerializer(object):
             if self.migration:
                 needed_migrations.append(self.migration)
             if self.deprecated:
-                common.logger.warning("[DEPRECATION WARNING]: Field '{}' in '{}' is deprecated: {}".format(file, field_name, self.deprecated))
+                common.logger.warning("[DEPRECATION WARNING] D001: Field '{field}' in '{file}' is deprecated: {message}".format(field=field_name, file=file, message=self.deprecated))
 
             ok = False
             err = []

--- a/test/e2e/dmake.yml
+++ b/test/e2e/dmake.yml
@@ -12,7 +12,7 @@ env:
 docker:
   root_image:
     name: ubuntu
-    tag: 16.04
+    tag: "16.04"
 
 services:
   - service_name: test-external-dependency-nginx
@@ -39,6 +39,8 @@ services:
         build:
           context: .
           dockerfile: ./deploy/Dockerfile
+      ports:
+        - container_port: True  # test bool type in ints deprecation warning D004
     tests:
       data_volumes:
         - container_volume: /dmake.yml

--- a/test/gpu/dmake.yml
+++ b/test/gpu/dmake.yml
@@ -22,4 +22,4 @@ services:
     tests:
       commands:
         - ./deploy/test-nvidia-smi.sh
-      timeout: 5
+      timeout: "5"  # test string type deprecation warning D003

--- a/test/k8s/dmake.yml
+++ b/test/k8s/dmake.yml
@@ -10,7 +10,7 @@ env:
 docker:
   root_image:
     name: ubuntu
-    tag: 18.04
+    tag: "18.04"
 
 services:
   - service_name: test-k8s

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -7,7 +7,8 @@ env:
       AMQP_URL: amqp://rabbitmq/dev
       SHARED_VOLUME_ROOT: /shared_volume_root_value
       ENV_EVALUATION_TEST: foobar
-      ENV_OVERRIDE_TEST: 1
+      ENV_OVERRIDE_TEST: "1"
+      SHOULD_DEPRECATE_WARN_STRING: 1
   branches:
     master:
       variables:
@@ -21,7 +22,7 @@ volumes:
 docker:
   root_image:
     name: ubuntu
-    tag: 16.04
+    tag: "16.04"
   base_image:
     name: dmake-test-web-base
     install_scripts:
@@ -35,14 +36,14 @@ services:
     needed_services:
       - service_name: test-worker:ubuntu-1604
         env:
-          TEST_SHARED_VOLUME: 1
-          TEST_ENV_OVERRIDE: 1
+          TEST_SHARED_VOLUME: "1"
+          TEST_ENV_OVERRIDE: "1"
           ENV_OVERRIDE_TEST3: from_needed_service_env
           ENV_OVERRIDE_TEST5: from_needed_service_env
       - service_name: test-worker:ubuntu-1804
         link_name: worker-ubuntu-1804
         env:
-          TEST_SHARED_VOLUME: 1
+          TEST_SHARED_VOLUME: "1"
     config:
       docker_image:
         entrypoint: deploy/entrypoint.sh
@@ -89,7 +90,7 @@ services:
       - service_name: test-worker:ubuntu-1804
         link_name: worker-ubuntu-1804
         env:
-          TEST_SHARED_VOLUME: 1
+          TEST_SHARED_VOLUME: "1"
         needed_for:
           test: false
     needed_links:
@@ -99,8 +100,8 @@ services:
         entrypoint: deploy/entrypoint.sh
         start_script: deploy/start.sh
       env_override:
-        ENV_OVERRIDE_TEST: 2
-        ENV_OVERRIDE_TEST2: 3
+        ENV_OVERRIDE_TEST: "2"
+        ENV_OVERRIDE_TEST2: "3"
       ports:
         - container_port: 8000
           # no host_port: always random port

--- a/tutorial/e2e/dmake.yml
+++ b/tutorial/e2e/dmake.yml
@@ -10,7 +10,7 @@ env:
 docker:
   root_image:
     name: ubuntu
-    tag: 16.04
+    tag: "16.04"
 
 services:
   - service_name: e2e


### PR DESCRIPTION
related to #432

warning for #432 example:
```
[DEPRECATION WARNING] D002: Field 'env:default:variables' in 'dmake.yml' should contain a string, it currently contains a <class 'bool'>: True. Add quotes arount the value.
[DEPRECATION WARNING] D002: Field 'docker:root_image:tag' in 'dmake.yml' should contain a string, it currently contains a <class 'float'>: 18.04. Add quotes arount the value.
[DEPRECATION WARNING] D004: Field 'services:config:ports:container_port' in 'dmake.yml' should contain an int, it currently contains a bool: True.
```