### PR TITLE
Fix DMAKE_TELEPRESENCE_ARGS env var

### DIFF
--- a/dmake/utils/dmake_run_docker
+++ b/dmake/utils/dmake_run_docker
@@ -58,7 +58,7 @@ DOCKER_RUN_ARGS+=( --name ${NAME} "$@" )
 
 # support telepresence
 if [[ "${DMAKE_TELEPRESENCE}" == '1' ]]; then
-  telepresence "${DMAKE_TELEPRESENCE_ARGS[@]}" --docker-run "${DOCKER_RUN_ARGS[@]}"
+  telepresence ${DMAKE_TELEPRESENCE_ARGS} --docker-run "${DOCKER_RUN_ARGS[@]}"
 else
   docker run "${DOCKER_RUN_ARGS[@]}"
 fi


### PR DESCRIPTION
At that point in execution it's an environment variable, not a bash
variable that can store an array.

=> Usage: DMAKE_TELEPRESENCE_ARGS="--foo --bar"