### PR TITLE
Simplify base image building: raw root image 

### DIFF
--- a/dmake/templates/docker-base-raw-root-image/make_base.sh
+++ b/dmake/templates/docker-base-raw-root-image/make_base.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Copy config to /base (otherwise the docker commit does not save it)
+ROOT=$(dirname $0)
+rm -rf /base
+cp -r $ROOT /base
+cd /base
+
+if [ -d user ]; then
+    bash run_cmd.sh
+fi

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -27,7 +27,7 @@ docker:
     name: dmake-test-web-base
     install_scripts:
       - deploy/dependencies.sh
-    python_requirements: requirements.txt
+    python_requirements: requirements.txt  # deprecated
 
 services:
   - service_name: test-web

--- a/test/worker/deploy/dependencies.sh
+++ b/test/worker/deploy/dependencies.sh
@@ -5,16 +5,12 @@ export PARALLEL_BUILD=${PARALLEL_BUILD:-8}
 export MAKEFLAGS="${MAKEFLAGS} -j${PARALLEL_BUILD}"
 
 apt-get update
-apt-get --no-install-recommends -y install make cmake g++ wget tar
-
-# RabbitMQ
-apt-get --no-install-recommends -y install librabbitmq-dev
-
-# Boost
-apt-get --no-install-recommends -y install libboost-dev libboost-chrono-dev libboost-system-dev
-
-# Google Logging
-apt-get --no-install-recommends -y install libgoogle-glog-dev
+apt-get --no-install-recommends -y install \
+        ca-certificates \
+        make cmake g++ wget tar \
+        librabbitmq-dev \
+        libboost-dev libboost-chrono-dev libboost-system-dev \
+        libgoogle-glog-dev
 
 cd /tmp
 

--- a/test/worker/dmake.yml
+++ b/test/worker/dmake.yml
@@ -7,6 +7,7 @@ docker:
       name: dmake-test-worker-base
       variant: ubuntu-1604
       root_image: ubuntu:16.04
+      raw_root_image: true
       install_scripts:
         - deploy/dependencies.sh
     - <<: *base

--- a/tutorial/web/deploy/dependencies.sh
+++ b/tutorial/web/deploy/dependencies.sh
@@ -3,6 +3,7 @@ set -e
 
 apt-get update
 apt-get --no-install-recommends -y install \
+        ca-certificates \
         curl python python-dev python-pip \
         make \
         iputils-ping

--- a/tutorial/web/dmake.yml
+++ b/tutorial/web/dmake.yml
@@ -10,6 +10,7 @@ docker:
   base_image:
     name: dmake-tutorial-web-base
     root_image: ubuntu:16.04
+    raw_root_image: true
     copy_files:
       - deploy/requirements.txt
     install_scripts:

--- a/tutorial/worker/deploy/dependencies.sh
+++ b/tutorial/worker/deploy/dependencies.sh
@@ -5,16 +5,12 @@ export PARALLEL_BUILD=${PARALLEL_BUILD:-8}
 export MAKEFLAGS="${MAKEFLAGS} -j${PARALLEL_BUILD}"
 
 apt-get update
-apt-get --no-install-recommends -y install make cmake g++ wget tar
-
-# RabbitMQ
-apt-get --no-install-recommends -y install librabbitmq-dev
-
-# Boost
-apt-get --no-install-recommends -y install libboost-dev libboost-chrono-dev libboost-system-dev
-
-# Google Logging
-apt-get --no-install-recommends -y install libgoogle-glog-dev
+apt-get --no-install-recommends -y install \
+        ca-certificates \
+        make cmake g++ wget tar \
+        librabbitmq-dev \
+        libboost-dev libboost-chrono-dev libboost-system-dev \
+        libgoogle-glog-dev
 
 cd /tmp
 

--- a/tutorial/worker/dmake.yml
+++ b/tutorial/worker/dmake.yml
@@ -10,6 +10,7 @@ docker:
   base_image:
     name: dmake-tutorial-worker-base
     root_image: ubuntu:16.04
+    raw_root_image: true
     install_scripts:
       - deploy/dependencies.sh
 


### PR DESCRIPTION
closes #93 
related to #118

## Add `raw_root_image` mode to build the base image

Only use user install_scripts to build the base image from the root:
deprecate old way where dmake added many things by itself to the root
image (and assumed it was debian-based), to support deprecated features:
- dmake-managed python requirements (raise error when used with raw_root_image)
- ssh agent/key in the build container

It allow using non debian-based root images (just requires bash, which
could be relaxed too).

It should be faster to build too: less apt install commands.

## Add tests and update tutorial to use raw_root_image
Main change: need to install 'ca-certificates' apt package manually.