### PR TITLE
Test non-regression trailing slash in html_report dir copy

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -583,7 +583,7 @@ def generate_command_pipeline(file, cmds):
         elif cmd == "publishHTML":
             container_html_directory = os.path.join(kwargs['mount_point'], kwargs['directory'])
             host_html_directory = os.path.join(common.cache_dir, 'tests_results', str(uuid.uuid4()), kwargs['service_name'].replace(':', '-'), kwargs['directory'])
-            write_line('''sh('dmake_test_get_results "%s" "%s" "%s"')''' % (kwargs['service_name'], container_html_directory, host_html_directory))
+            write_line('''sh('dmake_test_get_results "%s" "%s" "%s"')''' % (kwargs['service_name'], container_html_directory, host_html_directory.rstrip('/')))
             write_line("publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: '%s', reportFiles: '%s', reportName: '%s'])" % (host_html_directory, kwargs['index'], kwargs['title'].replace("'", "\'")))
             write_line('''sh('rm -rf "%s"')''' % host_html_directory)
         else:

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -81,7 +81,7 @@ services:
           --with-id
       junit_report: nosetests.xml
       html_report:
-        directory: cover
+        directory: cover/
         title: Web HTML coverage report
       cobertura_report: coverage.xml
 


### PR DESCRIPTION
Support test `html_report.directory` ending with `/` on jenkins

Previously it failed in `docker cp`:
```
invalid output path: directory
"/repo/.dmake/tests_results/xxx/app/service/cover"
does not exist
```

=> `docker cp` is not perfectly specified with trailing slashes, but
it seems to work as expected when removing it.

Tested with docker 19.03.3.