### PR TITLE
Test kubernetes deployment manifest templates in PRs

### DIFF
--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -128,6 +128,15 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
 
     dmake_with_dependencies = params.DMAKE_WITH_DEPENDENCIES ? '' : '--standalone'
 
+
+    if (is_pr && dmake_command == 'test') {
+        echo "First: kubernetes deploy dry-run (just plan deployment on target branch to validate kubernetes manifests templates)"
+        sh "${params.CUSTOM_ENVIRONMENT} DMAKE_SKIP_TESTS=1 python3 \$(which dmake) deploy ${dmake_with_dependencies} '${params.DMAKE_APP}' --branch ${env.CHANGE_TARGET}"
+        // skip execution
+        echo "Kubernetes deploy dry-run finished in success!"
+    }
+
+    echo "Now really running dmake"
     sh "${params.CUSTOM_ENVIRONMENT} python3 \$(which dmake) ${dmake_command} ${dmake_with_dependencies} '${params.DMAKE_APP}'"
     load 'DMakefile'
 }


### PR DESCRIPTION
MVP for #415

It works by just planning/generating the deployment step (in practice
also the build step as it's not skippable...): all files are read,
template instantiated, and somewhat validated by kubectl dry-run.

It thus catches:
- missing referenced files
- wrong templates (undefined variable)
- some wrong k8s manifest: unknown fields, etc, but not all
  issues (e.g. env[].value yaml type is *not* checked to be a string)
  - it does check some schema validation via remote api definition (properly since #358)

It also supports no deployment (i.e. no `deploy` section (which is different than empty `deploy` array, which asks dmake to push docker images), now required when images are local only (no `foobar/` prefix)).

This will still test the k8s deploy dry-run with `DMAKE_SKIP_TESTS=1`, which is useful. To really skip that: change the DMAKE_COMMAND: not empty nor test (which means dry-run test deployment is mandatory when asking for tests, which is fine).

Later it could be integrated to dmake itself, but there are tricky
parts:
- is it a new command? or included in `test` ? or in `deploy`?
- we do need the target branch to trigger the deployment (there is a
  branch whitelist in dmake.yml controlling deployment)