### PR TITLE
install.sh: support .{bash,zsh}rc with no trailing newline

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -145,7 +145,7 @@ LINE="source ${CONFIG_FILE}"
 for SHRC in `ls ~/\.*shrc`; do
     if [ -z "`grep \"${LINE}\" ${SHRC}`" ]; then
         echo "We detected a shell config file here: ${SHRC}, patching to source ${CONFIG_FILE}"
-        echo "${LINE}" >> ${SHRC}
+        echo -e "\n${LINE}" >> ${SHRC}
     else
         echo "Patched ${SHRC} to source ${CONFIG_FILE}"
     fi


### PR DESCRIPTION
Previously it would append the `source $HOME/.dmake/config.sh` string in the last line if no trailing newline, breaking both lines intent.