### PR TITLE
Remove ${SERVICE_NAME} in kubernetes yaml templates

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -790,7 +790,6 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
             user_manifest_path = os.path.join(tmp_dir, user_manifest_filename)
             change_cause = "DMake deploy %s from repo %s#%s (%s)" % (deploy_name, common.repo, common.branch, common.commit_id)
             template_default_context = {
-                'SERVICE_NAME': deploy_name,
                 'CHANGE_CAUSE': change_cause,
                 'DOCKER_IMAGE_NAME': image_name,
                 'CONFIGMAP_ENV_NAME': configmap_name


### PR DESCRIPTION
Closes #455 

It was in fact not needed for a long time: k8s completion wait is done
via dmake-injected labels, not Deployment name.
