### PR TITLE
Release command: fix prerelease bumping

### DIFF
--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -26,11 +26,27 @@ def tag_to_version(tag):
 
 
 def is_valid_bump(prev_version, next_version):
+    """Returns True if the bump is valid according to Semantic Versionning
+
+    A bump is valid if:
+    -   The release version is strictly higher than the current version, including extensions
+    -   No version is skipped when bumping the major/minor/patch part or
+        finalizing (=removing extensions, i.e. prerelease and build parts).
+
+    Note that a bump is invalid if only the build part differs. This behaviour may
+    be too restrictive and change later.
+
+    More info: https://semver.org or see examples in test/test_release_command.py
+
+    Args:
+        prev_version (VersionInfo): the current version
+        next_version (VersionInfo): the version to release
+    """
     if prev_version >= next_version:
         return False
 
-    # Additional check: ensure no version is skip
-    # Pre releases and builds are not taken in account as their token can change
+    # Ensure no version is skipped
+    # Prereleases and builds are not taken in account as their token can change
     # Example: (1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta)
     if prev_version.prerelease is None and next_version.prerelease is None and \
             prev_version.build is None and next_version.build is None:
@@ -38,6 +54,7 @@ def is_valid_bump(prev_version, next_version):
                semver.bump_minor(str(prev_version)) == str(next_version) or \
                semver.bump_patch(str(prev_version)) == str(next_version)
 
+    # Ensure no version is skipped if finalizing the version
     elif prev_version.prerelease is not None and next_version.prerelease is None:
         return tag_to_version(semver.finalize_version(str(prev_version))) == next_version
     else:

--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -1,10 +1,10 @@
 import os
+
 import dmake.common as common
 import inquirer
 import semver
-from github import Github
-
 from dmake.common import DMakeException
+from github import Github
 
 
 def remove_tag_prefix(tag):
@@ -25,11 +25,13 @@ def entry_point(options):
     token = os.getenv('DMAKE_GITHUB_TOKEN', None)
     owner = os.getenv('DMAKE_GITHUB_OWNER', None)
     if token is None:
-        raise DMakeException("Your need to define your Github Access Token by setting the DMAKE_GITHUB_TOKEN environment variable")
+        raise DMakeException(
+            "Your need to define your Github Access Token by setting the DMAKE_GITHUB_TOKEN environment variable")
     if owner is None:
-        raise DMakeException("Your need to define your Github account/organization name by setting the DMAKE_GITHUB_OWNER environment variable")
+        raise DMakeException(
+            "Your need to define your Github account/organization name by setting the DMAKE_GITHUB_OWNER environment variable")
 
-    # Acces Github repo
+    # Access Github repo
     g = Github(token)
     owner = g.get_user(owner)
     repo = owner.get_repo(app)
@@ -87,19 +89,22 @@ def entry_point(options):
         no_prefix_prev = remove_tag_prefix(prev_version.name)
         no_prefix_next_without_prerelease = no_prefix_next.split('-')[0]
         if semver.bump_major(no_prefix_prev) != no_prefix_next_without_prerelease and \
-           semver.bump_minor(no_prefix_prev) != no_prefix_next_without_prerelease and \
-           semver.bump_patch(no_prefix_prev) != no_prefix_next_without_prerelease and \
-           semver.bump_prerelease(no_prefix_prev) != no_prefix_next_without_prerelease and \
-            (release_key.major != prev_key.major or
-             release_key.minor != prev_key.minor or
-             release_key.patch != prev_key.patch or
-             release_key.prerelease != prev_key.prerelease):
-            raise DMakeException("Could not find any corresponding correct candidate previous version when bumping to {tag}. Previous version candidate: {prev}".format(tag=release_tag.name, prev=prev_version.name))
+                semver.bump_minor(no_prefix_prev) != no_prefix_next_without_prerelease and \
+                semver.bump_patch(no_prefix_prev) != no_prefix_next_without_prerelease and \
+                semver.bump_prerelease(no_prefix_prev) != no_prefix_next_without_prerelease and \
+                (release_key.major != prev_key.major or
+                 release_key.minor != prev_key.minor or
+                 release_key.patch != prev_key.patch or
+                 release_key.prerelease != prev_key.prerelease):
+            raise DMakeException(
+                "Could not find any corresponding correct candidate previous version when bumping to {tag}. Previous version candidate: {prev}".format(
+                    tag=release_tag.name, prev=prev_version.name))
 
         # Compute change log
         # TODO: use https://github.com/vaab/gitchangelog
         common.run_shell_command2("git fetch --tags --quiet")
-        change_log_cmd = "git log {prev}...{target} --pretty=%s".format(prev=prev_version.commit.sha, target=target_commit.sha)
+        change_log_cmd = "git log {prev}...{target} --pretty=%s".format(prev=prev_version.commit.sha,
+                                                                        target=target_commit.sha)
         change_log = common.run_shell_command2(change_log_cmd)
 
         if change_log == "":
@@ -110,5 +115,8 @@ def entry_point(options):
         change_log = '\n'.join(['- ' + line for line in change_log.split('\n')])
 
     # Creates the release
-    repo.create_git_release(release_tag.name, release_tag.name, change_log, prerelease=prerelease, target_commitish=target_commit)
-    print("Done ! Check it at: https://github.com/{owner}/{repo}/releases/tag/{tag}".format(owner=owner.name, repo=repo.name, tag=release_tag.name))
+    repo.create_git_release(release_tag.name, release_tag.name, change_log, prerelease=prerelease,
+                            target_commitish=target_commit)
+    print("Done ! Check it at: https://github.com/{owner}/{repo}/releases/tag/{tag}".format(owner=owner.name,
+                                                                                            repo=repo.name,
+                                                                                            tag=release_tag.name))

--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -20,7 +20,7 @@ def tag_to_version(tag):
         tag (str): the string to convert into version
     """
     try:
-        return semver.VersionInfo.parse(remove_tag_prefix(tag))
+        return semver.parse_version_info(remove_tag_prefix(tag))
     except ValueError:
         return None
 
@@ -34,11 +34,12 @@ def is_valid_bump(prev_version, next_version):
     # Example: (1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta)
     if prev_version.prerelease is None and next_version.prerelease is None and \
             prev_version.build is None and next_version.build is None:
-        return prev_version.next_version("major") == next_version or \
-               prev_version.next_version("minor") == next_version or \
-               prev_version.next_version("patch") == next_version
+        return semver.bump_major(str(prev_version)) == str(next_version) or \
+               semver.bump_minor(str(prev_version)) == str(next_version) or \
+               semver.bump_patch(str(prev_version)) == str(next_version)
+
     elif prev_version.prerelease is not None and next_version.prerelease is None:
-        return prev_version.finalize_version() == next_version
+        return tag_to_version(semver.finalize_version(str(prev_version))) == next_version
     else:
         return True
 

--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -75,13 +75,16 @@ def entry_point(options):
 
     # Ask for previous version
     if release_tag is None:
+        choices = []
+        for key in sorted_release_versions:
+            if (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[(key.major, key.minor)] == key:
+                choices.append(github_tag_list[key].name)
+        choices.append('Other')
         questions = [
             inquirer.List(
                 'release_tag',
                 message="Here are only the latest tags per major-minor version. Which tag do you want to release on?",
-                choices=[github_tag_list[key].name for key in sorted_release_versions if
-                         (key.major, key.minor) in latest_per_major_minor and latest_per_major_minor[
-                             (key.major, key.minor)] == key] + ['Other'],
+                choices=choices,
             ),
         ]
         answers = inquirer.prompt(questions)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ oauthlib>=2.0.6
 requests-oauthlib==0.8.0
 inquirer==2.2.0
 PyGithub==1.39
-semver==2.10.2
+semver==2.8.0
 graphviz==0.8.4
 pytest==3.8.0
 argcomplete==1.9.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ oauthlib>=2.0.6
 requests-oauthlib==0.8.0
 inquirer==2.2.0
 PyGithub==1.39
-semver==2.8.0
+semver==2.10.2
 graphviz==0.8.4
 pytest==3.8.0
 argcomplete==1.9.4

--- a/test/test_release_command.py
+++ b/test/test_release_command.py
@@ -1,8 +1,7 @@
 import pytest
 import semver
 
-from dmake.commands.release import is_valid_bump
-
+from dmake.commands.release import is_valid_bump, tag_to_version
 
 @pytest.mark.parametrize("prev_version_str,next_version_str,is_valid", [
     ('0.2.0', '0.3.0-rc1', True),
@@ -18,6 +17,6 @@ from dmake.commands.release import is_valid_bump
     ('1.0.0-beta+0', '1.0.0-alpha.1+45', False)
 ])
 def test_valid_bump(prev_version_str, next_version_str, is_valid):
-    prev_version = semver.VersionInfo.parse(prev_version_str)
-    next_version = semver.VersionInfo.parse(next_version_str)
+    prev_version = tag_to_version(prev_version_str)
+    next_version = tag_to_version(next_version_str)
     assert is_valid_bump(prev_version, next_version) == is_valid

--- a/test/test_release_command.py
+++ b/test/test_release_command.py
@@ -1,20 +1,33 @@
 import pytest
-import semver
 
 from dmake.commands.release import is_valid_bump, tag_to_version
 
+
 @pytest.mark.parametrize("prev_version_str,next_version_str,is_valid", [
-    ('0.2.0', '0.3.0-rc1', True),
+    # Bump patch
     ('0.2.0', '0.2.1', True),
+    ('0.2.0', '0.2.2', False),  # 0.2.1 is skipped
+
+    # Bump minor
     ('0.2.0', '0.3.0', True),
-    ('0.2.0', '1.2.0', False),
-    ('0.2.0', '0.2.2', False),
-    ('0.8.2', '0.8.3-dev1', True),
-    ('0.8.3-dev1', '0.8.3-dev2', True),
-    ('0.8.3', '0.8.3-dev1', False),
-    ('1.0.0-alpha', '1.0.0-alpha.1', True),
+    ('0.2.0', '0.3.0-rc1', True),  # pre-release of a new minor version
+
+    # Bump major
+    ('0.2.2', '1.0.0', True),
+    ('0.2.2-dev1', '0.2.2', True),  # finalize version
+    ('0.2.2-dev1', '1.0.0', False),  # 0.2.2 is skipped
+    ('0.2.2', '1.0.0-dev1', True),  # pre-release of a new major version
+    ('0.2.0', '1.2.0', False),  # 1.0.0 and 1.1.0 are skipped
+
+    # Bump prerelease
     ('1.0.0-alpha.1', '1.0.0-beta', True),
-    ('1.0.0-beta+0', '1.0.0-alpha.1+45', False)
+    ('0.8.3', '0.8.4-dev1', True),
+    ('0.8.3', '0.8.3-dev1', False),  # Need to bump major or minor or patch before new pre-release
+    ('1.0.0-beta+0', '1.0.0-alpha.1+45', False),  # alphabetical order is not respected
+
+    # Bump build
+    ('1.0.0-alpha', '1.0.0-alpha.1', True),
+    ('1.0.0-beta+12', '1.0.0-beta+56', False),  # Equal precedence, '1.0.0-beta+12' == '1.0.0-beta+56'
 ])
 def test_valid_bump(prev_version_str, next_version_str, is_valid):
     prev_version = tag_to_version(prev_version_str)

--- a/test/test_release_command.py
+++ b/test/test_release_command.py
@@ -1,0 +1,23 @@
+import pytest
+import semver
+
+from dmake.commands.release import is_valid_bump
+
+
+@pytest.mark.parametrize("prev_version_str,next_version_str,is_valid", [
+    ('0.2.0', '0.3.0-rc1', True),
+    ('0.2.0', '0.2.1', True),
+    ('0.2.0', '0.3.0', True),
+    ('0.2.0', '1.2.0', False),
+    ('0.2.0', '0.2.2', False),
+    ('0.8.2', '0.8.3-dev1', True),
+    ('0.8.3-dev1', '0.8.3-dev2', True),
+    ('0.8.3', '0.8.3-dev1', False),
+    ('1.0.0-alpha', '1.0.0-alpha.1', True),
+    ('1.0.0-alpha.1', '1.0.0-beta', True),
+    ('1.0.0-beta+0', '1.0.0-alpha.1+45', False)
+])
+def test_valid_bump(prev_version_str, next_version_str, is_valid):
+    prev_version = semver.VersionInfo.parse(prev_version_str)
+    next_version = semver.VersionInfo.parse(next_version_str)
+    assert is_valid_bump(prev_version, next_version) == is_valid


### PR DESCRIPTION
Close #462 (fix prerelease bumping)

- **Order** The check ensure the new version is strictly superior to the previous version.
- **Main parts** The check still ensure no version is skipped when bumping the major/minor/patch part or finalizing (=removing extensions, i.e. prerelease and build parts).
- **Prerelease** The releaser has now more flexibility on the pre-releases: they are not checked too much because they can vary a lot. For instance token can change between version (`alpha` -> `beta`) or between projects (`rc`, `dev`...) (https://semver.org/#spec-item-9). Only the alphabetical order is checked if all the other parts are identical
- **Build** If only the build part differs, there is no precedence (https://semver.org/#spec-item-10) and the bump is invalid (arbitrary choice, can change later)

---

Additional changes:
- Light refactoring
- Add a test on the version checking method