### PR TITLE
Raise error on empty DMAKE_GITHUB_TOKEN/DMAKE_GITHUB_OWNER env vars

### DIFF
--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -67,10 +67,10 @@ def entry_point(options):
 
     token = os.getenv('DMAKE_GITHUB_TOKEN', None)
     owner = os.getenv('DMAKE_GITHUB_OWNER', None)
-    if token is None:
+    if not token:
         raise DMakeException(
             "Your need to define your Github Access Token by setting the DMAKE_GITHUB_TOKEN environment variable")
-    if owner is None:
+    if not owner:
         raise DMakeException(
             "Your need to define your Github account/organization name by setting the DMAKE_GITHUB_OWNER environment variable")
 


### PR DESCRIPTION
They are set to empty string by the install.sh script...

Closes #459