### PR TITLE
Reject multiple kubernetes deployments on same dmake service, k8s context and namespace

### DIFF
--- a/test/k8s/dmake.yml
+++ b/test/k8s/dmake.yml
@@ -42,7 +42,7 @@ services:
           branches: [master]
           kubernetes:
             context: main
-            namespace: ${K8S_NAMESPACE}
+            namespace: ${K8S_NAMESPACE}-2
             config_maps:
               - name: dmake-test-k8s-configmap
                 from_files:


### PR DESCRIPTION
It was effectively not working because of per-stage pruning.

Closes #450.