### PR TITLE
Add k8s annotations, also in spec.template.metadata to force redeploy with the deploy timestamp

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import argparse
+from datetime import datetime
 import hashlib
 import io
 import logging
@@ -366,6 +367,7 @@ def init(_options, early_exit=False):
     global do_pull_config_dir
     global use_host_ports
     global session_id
+    global session_timestamp
     global change_detection
 
     options = _options
@@ -392,6 +394,7 @@ def init(_options, early_exit=False):
     root_dir = os.path.join(root_dir, '')  # make sure it is suffixed by /
 
     session_id = uuid.uuid4()
+    session_timestamp = datetime.utcnow()
 
     config_dir = os.getenv('DMAKE_CONFIG_DIR', None)
     if config_dir is None:

--- a/dmake/kubernetes.py
+++ b/dmake/kubernetes.py
@@ -12,7 +12,7 @@ def get_env_hash(env):
     return hashlib.sha256(serialized_env_binary).hexdigest()[:10]
 
 
-def generate_config_map(env, name, labels = None):
+def generate_config_map(env, name, labels = None, annotations = None):
     """Return a kubernetes manifest defining a ConfigMap storing `env`."""
     data = yaml.safe_load("""
 apiVersion: v1
@@ -20,35 +20,57 @@ kind: ConfigMap
 metadata:
   name: ""
   labels: {}
+  annotations: {}
 data: {}
 """)
     data['metadata']['name'] = name
     if labels:
         data['metadata']['labels'] = labels
+    if annotations:
+        data['metadata']['annotations'] = annotations
     data['data'] = env
     return data
 
 
-def generate_config_map_file(env, name_prefix, output_filepath, labels = None):
+def generate_config_map_file(env, name_prefix, output_filepath, labels = None, annotations = None):
     """Generate a ConfigMap manifest file with unique env-hashed name, and return the name."""
     env_hash = get_env_hash(env)
     name = "%s-env-%s" % (name_prefix, env_hash)
-    data = generate_config_map(env, name, labels)
+    data = generate_config_map(env, name, labels, annotations)
     with open(output_filepath, 'w') as configmap_file:
         yaml.dump(data, configmap_file, default_flow_style=False)
     return name
 
 
-def add_labels(resource, labels):
-    if 'labels' not in resource['metadata']:
-        resource['metadata']['labels'] = {}
-    resource['metadata']['labels'].update(labels)
+def add_metadata(resource, labels = None, annotations = None):
+    if labels:
+        if 'labels' not in resource['metadata']:
+            resource['metadata']['labels'] = {}
+        resource['metadata']['labels'].update(labels)
+    if annotations:
+        if 'annotations' not in resource['metadata']:
+            resource['metadata']['annotations'] = {}
+        resource['metadata']['annotations'].update(annotations)
 
 
-def dump_all_str_and_add_labels(data_str, labels, file=None):
-    data = common.yaml_ordered_load(data_str, all=True)
+def dump_all_str_and_add_metadata(data_str_or_list_of_str, labels=None, annotations=None, file=None):
+    """
+    Input:
+    - either a str for one or more yamls;
+    - or a list of str for one yaml
+    Output:
+    multi element yaml str (or written to file if specified), with labels and annotations injected in metadata (and annotations also added to spec.template.metadata when it exists).
+    """
+    if isinstance(data_str_or_list_of_str, list):
+        data = [common.yaml_ordered_load(data_str) for data_str in data_str_or_list_of_str]
+    else:
+        data = common.yaml_ordered_load(data_str_or_list_of_str, all=True)
     for resource in data:
-        add_labels(resource, labels)
+        # add to metadata
+        add_metadata(resource, labels, annotations)
+        # add to spec.template.metadata if spec.template exists, e.g. to pods templates
+        if 'spec' in resource and 'template' in resource['spec']:
+            add_metadata(resource['spec']['template'], annotations=annotations)
     return common.yaml_ordered_dump(data, file, all=True)
 
 

--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Usage:
-# dmake_deploy_kubernetes DMAKE_TMP_DIR KUBE_CONTEXT NAMESPACE SERVICE_NAME REPO BRANCH COMMIT_ID ARGS...
+# dmake_deploy_kubernetes DMAKE_TMP_DIR KUBE_CONTEXT NAMESPACE SERVICE_NAME ARGS...
 #
 # Result:
 # Deploy resources on kubernetes, using ARGS as kubernetes manifest yaml files.
@@ -21,9 +21,6 @@ TMP_DIR=$1; shift
 CONTEXT=$1; shift
 NAMESPACE=$1; shift
 SERVICE=$1; shift
-REPO=$1; shift
-BRANCH="$1"; shift
-COMMIT=$1; shift
 
 BASE_ARGS=( --context=${CONTEXT} ${NAMESPACE:+--namespace=${NAMESPACE}} )
 
@@ -42,8 +39,6 @@ function echo_title() {
   echo
   echo [DMake] "$@"
 }
-
-deploy_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 echo_title Apply ${SERVICE} to kubernetes cluster ${CONTEXT}:
 
@@ -74,20 +69,6 @@ if [[ "${DMAKE_K8S_DRY_RUN}" == "1" ]]; then
   echo "dry-run, exiting"
   exit
 fi
-
-echo_title Annotate ${SERVICE} on kubernetes cluster ${CONTEXT}:
-# TODO currently not atomic: multiple apply can work in parallel, and this command may annotate the wrong version
-prefix="dmake.deepomatic.com"
-ANNOTATE_ARGS=( "${BASE_ARGS[@]}" annotate "${FILES_ARGS[@]}" "${FILES_NO_PRUNING_ARGS[@]}"
-                --overwrite=true --record=false
-                ${prefix}/deploy-timestamp="${deploy_timestamp}"
-                ${prefix}/service=${SERVICE}
-                ${prefix}/git-repository=${REPO}
-                ${prefix}/git-branch="${BRANCH}"
-                ${prefix}/git-revision=${COMMIT}
-              )
-echo kubectl "${ANNOTATE_ARGS[@]}"
-kubectl "${ANNOTATE_ARGS[@]}"
 
 echo_title Rollout status for ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
 


### PR DESCRIPTION
Before, when running dmake deploy locally, the image name didn't change, so the deployment spec.template usually didn't change (it did change when env var values changed), resulting in new code not deployed until pod deletion.
(in any case this still needs a `imagePullPolicy: Always` for these dev envs so k8s re-downloads the (new) docker image.

Now, set dmake annotations notably with timestamp (so it's unique) not only in metadata  but also in spec.template.metadata when spec.template exists; forcing a new deployment.

Also removed annotations set by dmake_deploy_kubernetes at runtime: it's all done at generation time now.

Later we could also set the kubernetes.io/change-cause this way (but maybe add it only at the top-level? maybe only for app/v1?).