### PR TITLE
Add dmake graph for services dependency graph generation

### DIFF
--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -38,7 +38,7 @@ argparser = argparse.ArgumentParser(prog='dmake')
 
 argparser.add_argument('--debug-graph', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes.")
 argparser.add_argument('--debug-graph-and-exit', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes then exit.")
-argparser.add_argument('--debug-graph-output-filename', default='dmake-services.gv', help="The generated DOT graph filename.")
+argparser.add_argument('--debug-graph-output-filename', default='dmake-services.debug.gv', help="The generated DOT graph filename.")
 argparser.add_argument('--debug-graph-output-format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
 
 subparsers = argparser.add_subparsers(dest='cmd', title='Commands')
@@ -51,6 +51,7 @@ parser_stop    = subparsers.add_parser('stop', help="Stop the containers lauched
 parser_shell   = subparsers.add_parser('shell', help="Run a shell session withing a docker container with the environment set up for a given service.")
 parser_deploy  = subparsers.add_parser('deploy', help="Deploy specified apps and services.")
 parser_release = subparsers.add_parser('release', help="Create a release of the app on Github.")
+parser_graph   = subparsers.add_parser('graph', help="Generate a visual graph of the app services dependencies (dot/graphviz format).")
 
 
 # "service" argument
@@ -76,6 +77,9 @@ parser_run.add_argument("--docker-links-volumes-persistence", "--no-docker-links
 parser_release.add_argument("app", help="Create the release for the given app.")
 parser_release.add_argument('-t', '--tag', nargs='?', help="The release tag from which the release will be created.")
 
+parser_graph.add_argument('--output', default='dmake-services.gv', help="The generated DOT graph filename.")
+parser_graph.add_argument('--format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
+
 parser_test.set_defaults(func=core.make)
 parser_run.set_defaults(func=core.make)
 parser_build.set_defaults(func=core.make)
@@ -83,6 +87,7 @@ parser_stop.set_defaults(func=commands.stop.entry_point)
 parser_shell.set_defaults(func=core.make)
 parser_deploy.set_defaults(func=core.make)
 parser_release.set_defaults(func=commands.release.entry_point)
+parser_graph.set_defaults(func=commands.graph.entry_point)
 
 
 # Shell completion

--- a/dmake/commands/__init__.py
+++ b/dmake/commands/__init__.py
@@ -1,2 +1,3 @@
 from . import stop
 from . import release
+from . import graph

--- a/dmake/commands/graph.py
+++ b/dmake/commands/graph.py
@@ -1,0 +1,52 @@
+import dmake.common as common
+import dmake.core as core
+
+
+def entry_point(options):
+    loaded_files = core.make(options, parse_files_only=True)
+
+    from graphviz import Digraph
+
+    def sanitize_id(name):
+        # there is a bug in graphviz around `:` escaping, see https://github.com/xflr6/graphviz/issues/53
+        return str(name).replace(':', '_')
+
+    def label(name, file):
+        return "<{}<br/><i><font point-size='10'>{}</font></i>>".format(name, file)
+
+    dot = Digraph(comment='DMake Services', filename=options.output, format=options.format)
+    services_graph = Digraph()
+    links_graph = Digraph()
+    links_graph.attr(rank='same')
+
+    for file, dmake_file in loaded_files.items():
+        app_name = dmake_file.get_app_name()
+
+        for service in dmake_file.get_services():
+            service_full_name = "%s/%s" % (app_name, service.service_name)
+
+            service_node_id = sanitize_id(service_full_name)
+            services_graph.node(service_node_id,
+                                label=label(service_full_name, file),
+                                shape='box')
+
+            for dep in service.needed_services:
+                dep_full_name = "%s/%s" % (app_name, dep.service_name)
+                dot.edge(service_node_id, sanitize_id(dep_full_name))
+
+            for link_name in service.needed_links:
+                link_full_name = "link/%s/%s" % (app_name, link_name)
+                dot.edge(service_node_id, sanitize_id(link_full_name), style='dashed')
+
+        for link in dmake_file.docker_links:
+            link_full_name = "link/%s/%s" % (app_name, link.link_name)
+            link_name = "%s/%s" % (app_name, link.link_name)
+            links_graph.node(sanitize_id(link_full_name),
+                             label=label(link_name, file),
+                             shape='')
+
+    dot.subgraph(services_graph)
+    dot.subgraph(links_graph)
+
+    dot.render()
+    common.logger.info("Generated graph in files '{}' and '{}'. You can open the first with `xdot` for example.".format(options.output, options.output + '.' + options.format))

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -311,7 +311,7 @@ def get_dmake_build_type():
 
 ###############################################################################
 
-def dump_dot_graph(dependencies, nodes_height):
+def dump_debug_dot_graph(dependencies, nodes_height):
     if not generate_dot_graph:
         return
 

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -827,7 +827,7 @@ def make(options, parse_files_only=False):
     # cleanup service_dependencies: remove nodes with no depth: they are not related (directly or by dependency) to dmake-command-created leaves: they are not needed
     service_dependencies = dict(filter(lambda service_deps: service_deps[0] in build_files_order, service_dependencies.items()))
 
-    debug_dot_graph = common.dump_dot_graph(service_dependencies, build_files_order)
+    debug_dot_graph = common.dump_debug_dot_graph(service_dependencies, build_files_order)
     if common.exit_after_generate_dot_graph:
         print('Exiting after debug graph generation')
         return debug_dot_graph


### PR DESCRIPTION
Useful for dmake users to discover/understand the services dependencies graph.
The `dot` program is required to generate the graph; graphviz will throw an intelligible exception if it's missing.

Example with dmake own tutorial/test graph:
```
$ dmake graph --help
usage: dmake graph [-h] [--output OUTPUT] [--format FORMAT]

optional arguments:
  -h, --help       show this help message and exit
  --output OUTPUT  The generated DOT graph filename.
  --format FORMAT  The generated DOT graph format (`png`, `svg`, `pdf`, ...).

$ dmake graph
...
Generated graph in files 'dmake-services.gv' and 'dmake-services.gv.png'. You can open the first with `xdot` for example.
```
![dmake own tutorial/test graph](https://user-images.githubusercontent.com/1730297/97005387-ad06ed00-153e-11eb-988c-51f6411ad8a6.png)