### PR TITLE
Change detection trigger test v2: bugfix for non-trivial cases: Don't cascade back from the triggered parents on siblings

### DIFF
--- a/dmake/common.py
+++ b/dmake/common.py
@@ -154,6 +154,8 @@ def append_command(commands, cmd, prepend = False, **args):
 
 def run_shell_command(commands, ignore_error=False, additional_env=None, stdin=None, raise_on_return_code=False):
     """Deprecated, use run_shell_command2 instead."""
+    logger_ = logger.getChild('run_shell_command')
+    logger_.debug('running commands: %s' % (commands,))
     if not isinstance(commands, list):
         commands = [commands]
     if additional_env is None:

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -370,7 +370,7 @@ def init(_options, early_exit=False):
     global use_host_ports
     global session_id
     global session_timestamp
-    global change_detection
+    global change_detection, change_detection_override_dirs
 
     options = _options
     command = _options.cmd
@@ -387,6 +387,9 @@ def init(_options, early_exit=False):
     dot_graph_format = options.debug_graph_output_format
 
     change_detection = False  # set in core.make()
+    change_detection_override_dirs = os.getenv('DMAKE_CHANGE_DETECTION_OVERRIDE_DIRS', None)
+    if change_detection_override_dirs is not None:
+        change_detection_override_dirs = os.getenv('DMAKE_CHANGE_DETECTION_OVERRIDE_DIRS').split(',')
 
     try:
         root_dir, sub_dir = find_repo_root()

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -819,17 +819,18 @@ def make(options, parse_files_only=False):
         else:
             activate_service(loaded_files, service_providers, service_dependencies, common.command, auto_completed_app)
 
-    # (warninig: tree vocabulary is reversed here: `leaves` are the nodes with no parent dependency, and depth is the number of levels of child dependencies)
+    # (warning: tree vocabulary is reversed here: `leaves` are the nodes with no parent dependency, and depth is the number of levels of child dependencies)
     # check services circularity, and compute node depth
     sorted_leaves = check_no_circular_dependencies(service_dependencies)
     # get nodes leaves related to the dmake command (exclude notably `base` and `shared_volumes` which are created independently from the command)
     dmake_command_sorted_leaves = filter(lambda a_b__c: a_b__c[0][0] == common.command, sorted_leaves)
     # prepare reorder by computing shortest node depth starting from the dmake-command-created leaves
     build_files_order = order_dependencies(service_dependencies, dmake_command_sorted_leaves)
-    # cleanup service_dependencies: remove nodes with no depth: they are not related (directly or by dependency) to dmake-command-created leaves: they are not needed
-    service_dependencies = dict(filter(lambda service_deps: service_deps[0] in build_files_order, service_dependencies.items()))
 
-    debug_dot_graph = common.dump_debug_dot_graph(service_dependencies, build_files_order)
+    # cleanup service_dependencies for debug dot graph: remove nodes with no depth: they are not related (directly or by dependency) to dmake-command-created leaves: they are not needed
+    service_dependencies_pruned = dict(filter(lambda service_deps: service_deps[0] in build_files_order, service_dependencies.items()))
+
+    debug_dot_graph = common.dump_debug_dot_graph(service_dependencies_pruned, build_files_order)
     if common.exit_after_generate_dot_graph:
         print('Exiting after debug graph generation')
         return debug_dot_graph

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -30,6 +30,11 @@ def look_for_changed_directories():
     if common.force_full_deploy:
         return None
 
+    if common.change_detection_override_dirs is not None:
+        changed_dirs = common.change_detection_override_dirs
+        common.logger.info("Changed directories (forced via DMAKE_CHANGE_DETECTION_OVERRIDE_DIRS): %s", set(changed_dirs))
+        return changed_dirs
+
     if not common.target:
         tag = get_tag_name()
         common.logger.info("Looking for changes between HEAD and %s" % tag)

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -221,7 +221,7 @@ def activate_needed_services(loaded_files, service_providers, service_dependenci
 ###############################################################################
 
 def activate_service(loaded_files, service_providers, service_dependencies, command, service, service_customization=None):
-    common.logger.debug("activate_service: command: %s, service: %s, service_customization: %s" % (command, service, service_customization))
+    common.logger.debug("activate_service: command: %s,\tservice: %s,\tservice_customization: %s" % (command, service, service_customization))
     node = (command, service, service_customization)
     if command == 'test' and common.skip_tests:
         return []
@@ -278,7 +278,7 @@ def activate_service(loaded_files, service_providers, service_dependencies, comm
         if command == 'test':
             if common.options.with_dependencies and common.change_detection:
                 for parent_service in trigger_test_parents:
-                    common.logger.debug("activate_service: parent test: service: %s, parent service: %s" % (service, parent_service))
+                    common.logger.debug("activate_service: parent test: service: %s,\tparent service: %s" % (service, parent_service))
                     parent_node = activate_service(loaded_files, service_providers, service_dependencies, 'test', parent_service)[0]
                     if node not in service_dependencies[parent_node]:
                         service_dependencies[parent_node].append(node)

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -426,7 +426,7 @@ def check_no_circular_dependencies(dependencies):
         for dep in dependencies[key]:
             is_leaf[dep] = False
             if dep in walked_nodes:
-                raise DMakeException("Circular dependencies: %s" % ' -> '.join(reversed([dep] + walked_nodes)))
+                raise DMakeException("Circular dependencies: %s" % ' -> '.join(map(str, reversed([dep] + walked_nodes))))
             depth = max(depth, 1 + sub_check(dep, walked_nodes))
 
         tree_depth[key] = depth


### PR DESCRIPTION
related to #424

## Goal: in change detection mode, parent triggered tests now don't cascade back by activating sibling tests via sibling runs needed for parent test.

### Scenario: `dmake test +`, service Child1 source changes
Issue:
- Child1 test triggered by source change
- Parent test triggered by child source change (technically, when activating Child1 service for command==test)
- Parent test needs Child1 and Child2 run
- Child2 run needs Child2 test <-- issue here: we should not test Child2; but we should keep the "`Child2 run`->`Child2 test`" dependency if for another reason `Child2 test` is created (e.g. Child2 sources have also changed, or Child2 test is triggered by one of its own children source changed (recursively))

### What this PR (last commit) does:
On change detection mode, only create the dependency from run node to
test node if test node already activated otherwise. Previously it
always created the test node in addition to linking run to test to
guarantee execution order.
That previous test node creation effectively cascaded down to most of 
the dependency DAG, resulting in inefficiently testing too much.

Only the services to test by change or parent trigger are explicitly
created, alas it's *not* guaranteed to be done before needing to add the
dependency because we fully work changed service by changed service
sequentially, so when multiple services have changed we don't know yet
if a test will be needed or not.

To work around that we symply add the run->test link ordering in a
second pass in make().

Added assert command != 'run' => service_customization == None in
activate_service as we use that previously implicit property in that
new second pass.


## Various cleanups
To make things easier to understand/debug in this area, this PR starts with multiple cleanup commits, they are all noop (or just change logging):
- Fix error when internal error 'circular dependencies' happens.
- More debug logs: all run_shell_commands
- change detection: add DMAKE_CHANGE_DETECTION_OVERRIDE_DIRS env var for easier tests
- Refactor find_active_files for better clarity
- Refactor: Stop touching `service_dependencies` simply for pruning for debug graph: use dedicated variable
- More aligned activate_service debug logs, with tabs