### PR TITLE
Workaround scripted pipeline 'echo' not always showing up in high-level interfaces

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -482,6 +482,7 @@ def generate_command_pipeline(file, cmds):
 
     if common.build_description is not None:
         write_line("currentBuild.description = '%s'" % common.build_description.replace("'", "\\'"))
+    write_line("def dmake_echo(message) { sh(script: \"echo $message\", label: message) }")
     write_line('try {')
     indent_level += 1
 
@@ -515,7 +516,7 @@ def generate_command_pipeline(file, cmds):
             write_line("}")
         elif cmd == "echo":
             message = kwargs['message'].replace("'", "\\'")
-            write_line("echo '%s'" % message)
+            write_line("dmake_echo '%s'" % message)
         elif cmd == "sh":
             commands = kwargs['shell']
             if isinstance(commands, str):


### PR DESCRIPTION
Some `echo` are displayed in step views, some not, no idea why. it seems the ones talking about `::shared_volume` are shown, others not, no idea why:
![before, classic](https://user-images.githubusercontent.com/1730297/102246161-b9844200-3efe-11eb-9fcb-4685d5127e3f.png)
![before, blueocean](https://user-images.githubusercontent.com/1730297/102246232-cdc83f00-3efe-11eb-98f8-9ef5512285a5.png)

May or may not be related to https://issues.jenkins.io/browse/JENKINS-53649

Implemented workaround from https://stackoverflow.com/a/58558537




