### PR TITLE
Parallel Execution on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,9 @@ node {
     if (params.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP) {
         env.DMAKE_PAUSE_ON_ERROR_BEFORE_CLEANUP=1
     }
+
+    // test parallel execution
+    env.DMAKE_PARALLEL_EXECUTION = 1
   }
   stage('Python 3.x') {
     sh "virtualenv -p python3 workspace/.venv3"

--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -39,6 +39,7 @@ argparser = argparse.ArgumentParser(prog='dmake')
 argparser.add_argument('--debug-graph', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes.")
 argparser.add_argument('--debug-graph-and-exit', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes then exit.")
 argparser.add_argument('--debug-graph-group-by', default='command', choices=['command', 'height'], help="Group nodes by <> in generated DOT graph.")
+argparser.add_argument('--debug-graph-pretty', '--no-debug-graph-pretty', default=True, action=common.FlagBooleanAction, help="Pretty or raw output for debug graph.")
 argparser.add_argument('--debug-graph-output-filename', help="The generated DOT graph filename. Defaults to 'dmake-services.debug.{group_by}.gv'")
 argparser.add_argument('--debug-graph-output-format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
 

--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -38,7 +38,8 @@ argparser = argparse.ArgumentParser(prog='dmake')
 
 argparser.add_argument('--debug-graph', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes.")
 argparser.add_argument('--debug-graph-and-exit', default=False, action='store_true', help="Generate dmake steps DOT graph for debug purposes then exit.")
-argparser.add_argument('--debug-graph-output-filename', default='dmake-services.debug.gv', help="The generated DOT graph filename.")
+argparser.add_argument('--debug-graph-group-by', default='command', choices=['command', 'height'], help="Group nodes by <> in generated DOT graph.")
+argparser.add_argument('--debug-graph-output-filename', help="The generated DOT graph filename. Defaults to 'dmake-services.debug.{group_by}.gv'")
 argparser.add_argument('--debug-graph-output-format', default='png', help="The generated DOT graph format (`png`, `svg`, `pdf`, ...).")
 
 subparsers = argparser.add_subparsers(dest='cmd', title='Commands')

--- a/dmake/commands/graph.py
+++ b/dmake/commands/graph.py
@@ -15,6 +15,8 @@ def entry_point(options):
         return "<{}<br/><i><font point-size='10'>{}</font></i>>".format(name, file)
 
     dot = Digraph(comment='DMake Services', filename=options.output, format=options.format)
+    dot.attr('node', shape='box', style='filled', fillcolor='grey95')
+    dot.attr('edge', color='grey50')
     services_graph = Digraph()
     links_graph = Digraph()
     links_graph.attr(rank='same')
@@ -27,8 +29,7 @@ def entry_point(options):
 
             service_node_id = sanitize_id(service_full_name)
             services_graph.node(service_node_id,
-                                label=label(service_full_name, file),
-                                shape='box')
+                                label=label(service_full_name, file))
 
             for dep in service.needed_services:
                 dep_full_name = "%s/%s" % (app_name, dep.service_name)
@@ -43,7 +44,7 @@ def entry_point(options):
             link_name = "%s/%s" % (app_name, link.link_name)
             links_graph.node(sanitize_id(link_full_name),
                              label=label(link_name, file),
-                             shape='')
+                             style='dashed,filled', color='grey50', fillcolor='grey98')
 
     dot.subgraph(services_graph)
     dot.subgraph(links_graph)

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -402,6 +402,7 @@ def init(_options, early_exit=False):
     global session_id
     global session_timestamp
     global change_detection, change_detection_override_dirs
+    global parallel_execution
 
     options = _options
     command = _options.cmd
@@ -423,6 +424,8 @@ def init(_options, early_exit=False):
     change_detection_override_dirs = os.getenv('DMAKE_CHANGE_DETECTION_OVERRIDE_DIRS', None)
     if change_detection_override_dirs is not None:
         change_detection_override_dirs = os.getenv('DMAKE_CHANGE_DETECTION_OVERRIDE_DIRS').split(',')
+
+    parallel_execution = os.getenv('DMAKE_PARALLEL_EXECUTION', '0') != '0'
 
     try:
         root_dir, sub_dir = find_repo_root()

--- a/test/test-resources/graph.build.test-web.gv
+++ b/test/test-resources/graph.build.test-web.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -9,7 +8,7 @@ None
 height=0"]
 	}
 	"('build_docker', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
 dmake-test/test-web

--- a/test/test-resources/graph.deploy.*.gv
+++ b/test/test-resources/graph.deploy.*.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=2"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1604::base
 None
@@ -26,11 +26,11 @@ height=0"]
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
 None
-height=5"]
+height=0"]
 		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
 dmake-test/test-external-dependency-nginx
 None
-height=3"]
+height=0"]
 		"('build_docker', 'dmake-test/test-gpu', None)" [label="build_docker
 dmake-test/test-gpu
 None
@@ -42,11 +42,11 @@ height=0"]
 		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
 dmake-test/test-web
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-worker2', None)" [label="build_docker
 dmake-test/test-worker2
 None
@@ -94,7 +94,7 @@ height=7"]
 		"('deploy', 'dmake-test/test-external-dependency-nginx', None)" [label="deploy
 dmake-test/test-external-dependency-nginx
 None
-height=6"]
+height=2"]
 		"('deploy', 'dmake-test/test-gpu', None)" [label="deploy
 dmake-test/test-gpu
 None
@@ -106,11 +106,11 @@ height=2"]
 		"('deploy', 'dmake-test/test-web', None)" [label="deploy
 dmake-test/test-web
 None
-height=6"]
+height=5"]
 		"('deploy', 'dmake-test/test-web2', None)" [label="deploy
 dmake-test/test-web2
 None
-height=6"]
+height=4"]
 		"('deploy', 'dmake-test/test-worker2', None)" [label="deploy
 dmake-test/test-worker2
 None
@@ -118,11 +118,11 @@ height=3"]
 		"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" [label="deploy
 dmake-test/test-worker:ubuntu-1604
 None
-height=5"]
+height=3"]
 		"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" [label="deploy
 dmake-test/test-worker:ubuntu-1804
 None
-height=5"]
+height=3"]
 	}
 	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
 	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
@@ -153,11 +153,11 @@ height=5"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx2)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
 dmake-test/test-web
 test-web (web)
@@ -165,7 +165,7 @@ height=5"]
 		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
 dmake-test/test-web2
 test-web2 (web2)
-height=5"]
+height=4"]
 		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
 dmake-test/test-worker:ubuntu-1604
 test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
@@ -192,7 +192,7 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
 	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
@@ -227,7 +227,7 @@ height=6"]
 		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
 dmake-test/test-external-dependency-nginx
 None
-height=4"]
+height=1"]
 		"('test', 'dmake-test/test-gpu', None)" [label="test
 dmake-test/test-gpu
 None
@@ -243,7 +243,7 @@ height=4"]
 		"('test', 'dmake-test/test-web2', None)" [label="test
 dmake-test/test-web2
 None
-height=4"]
+height=2"]
 		"('test', 'dmake-test/test-worker2', None)" [label="test
 dmake-test/test-worker2
 None

--- a/test/test-resources/graph.deploy.*.gv
+++ b/test/test-resources/graph.deploy.*.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -21,7 +20,7 @@ height=0"]
 	"('build_docker', 'dmake-test/test-worker2', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
@@ -85,7 +84,7 @@ height=1"]
 	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
+	subgraph "group deploy" {
 		rank=same
 		"('deploy', 'dmake-test/test-e2e', None)" [label="deploy
 dmake-test/test-e2e
@@ -148,7 +147,7 @@ height=3"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
@@ -176,14 +175,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=3"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume
@@ -218,7 +217,7 @@ height=0"]
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group test" {
 		rank=same
 		"('test', 'dmake-test/test-e2e', None)" [label="test
 dmake-test/test-e2e

--- a/test/test-resources/graph.deploy.test-e2e.gv
+++ b/test/test-resources/graph.deploy.test-e2e.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -20,7 +19,7 @@ height=0"]
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
@@ -66,7 +65,7 @@ height=1"]
 	"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1604', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)"
 	"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
+	subgraph "group deploy" {
 		rank=same
 		"('deploy', 'dmake-test/test-e2e', None)" [label="deploy
 dmake-test/test-e2e
@@ -117,7 +116,7 @@ height=3"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
@@ -145,14 +144,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=3"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume
@@ -184,7 +183,7 @@ height=0"]
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group test" {
 		rank=same
 		"('test', 'dmake-test/test-e2e', None)" [label="test
 dmake-test/test-e2e

--- a/test/test-resources/graph.deploy.test-e2e.gv
+++ b/test/test-resources/graph.deploy.test-e2e.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=2"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1604::base
 None
@@ -25,19 +25,19 @@ height=0"]
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
 None
-height=5"]
+height=0"]
 		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
 dmake-test/test-external-dependency-nginx
 None
-height=3"]
+height=0"]
 		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
 dmake-test/test-web
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1604
 None
@@ -75,23 +75,23 @@ height=7"]
 		"('deploy', 'dmake-test/test-external-dependency-nginx', None)" [label="deploy
 dmake-test/test-external-dependency-nginx
 None
-height=6"]
+height=2"]
 		"('deploy', 'dmake-test/test-web', None)" [label="deploy
 dmake-test/test-web
 None
-height=6"]
+height=5"]
 		"('deploy', 'dmake-test/test-web2', None)" [label="deploy
 dmake-test/test-web2
 None
-height=6"]
+height=4"]
 		"('deploy', 'dmake-test/test-worker_ubuntu-1604', None)" [label="deploy
 dmake-test/test-worker:ubuntu-1604
 None
-height=5"]
+height=3"]
 		"('deploy', 'dmake-test/test-worker_ubuntu-1804', None)" [label="deploy
 dmake-test/test-worker:ubuntu-1804
 None
-height=5"]
+height=3"]
 	}
 	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('build_docker', 'dmake-test/test-external-dependency-nginx', None)"
 	"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" -> "('test', 'dmake-test/test-external-dependency-nginx', None)"
@@ -122,11 +122,11 @@ height=5"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx2)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
 dmake-test/test-web
 test-web (web)
@@ -134,7 +134,7 @@ height=5"]
 		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
 dmake-test/test-web2
 test-web2 (web2)
-height=5"]
+height=4"]
 		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
 dmake-test/test-worker:ubuntu-1604
 test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
@@ -161,7 +161,7 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
 	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
@@ -193,7 +193,7 @@ height=6"]
 		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
 dmake-test/test-external-dependency-nginx
 None
-height=4"]
+height=1"]
 		"('test', 'dmake-test/test-web', None)" [label="test
 dmake-test/test-web
 None
@@ -201,7 +201,7 @@ height=4"]
 		"('test', 'dmake-test/test-web2', None)" [label="test
 dmake-test/test-web2
 None
-height=4"]
+height=2"]
 		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
 dmake-test/test-worker:ubuntu-1604
 None

--- a/test/test-resources/graph.deploy.test-k8s.gv
+++ b/test/test-resources/graph.deploy.test-k8s.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-k8s', None)" [label="build_docker
 dmake-test/test-k8s
@@ -10,7 +9,7 @@ height=0"]
 	}
 	"('deploy', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
 	"('deploy', 'dmake-test/test-k8s', None)" -> "('test', 'dmake-test/test-k8s', None)"
-	{
+	subgraph "group deploy" {
 		rank=same
 		"('deploy', 'dmake-test/test-k8s', None)" [label="deploy
 dmake-test/test-k8s
@@ -18,7 +17,7 @@ None
 height=2"]
 	}
 	"('test', 'dmake-test/test-k8s', None)" -> "('build_docker', 'dmake-test/test-k8s', None)"
-	{
+	subgraph "group test" {
 		rank=same
 		"('test', 'dmake-test/test-k8s', None)" [label="test
 dmake-test/test-k8s

--- a/test/test-resources/graph.run.test-e2e.gv
+++ b/test/test-resources/graph.run.test-e2e.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -20,7 +19,7 @@ height=0"]
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
@@ -70,7 +69,7 @@ height=1"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-e2e', None)" [label="run
 dmake-test/test-e2e
@@ -102,14 +101,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=2"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume

--- a/test/test-resources/graph.run.test-e2e.gv
+++ b/test/test-resources/graph.run.test-e2e.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=1"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1604::base
 None
@@ -25,19 +25,19 @@ height=0"]
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
 None
-height=3"]
+height=0"]
 		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
 dmake-test/test-external-dependency-nginx
 None
-height=2"]
+height=0"]
 		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
 dmake-test/test-web
 None
-height=2"]
+height=1"]
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=2"]
+height=1"]
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1604
 None
@@ -79,11 +79,11 @@ height=4"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx)
-height=3"]
+height=1"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx2)
-height=3"]
+height=1"]
 		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
 dmake-test/test-web
 test-web (web)
@@ -118,6 +118,6 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 }

--- a/test/test-resources/graph.run.test-web2.gv
+++ b/test/test-resources/graph.run.test-web2.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=1"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1804__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1804::base
 None
@@ -19,7 +19,7 @@ height=0"]
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=2"]
+height=1"]
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1804
 None
@@ -60,6 +60,6 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 }

--- a/test/test-resources/graph.run.test-web2.gv
+++ b/test/test-resources/graph.run.test-web2.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -14,7 +13,7 @@ height=0"]
 	}
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
@@ -32,7 +31,7 @@ height=1"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-web2', None)" [label="run
 dmake-test/test-web2
@@ -44,14 +43,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=2"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume

--- a/test/test-resources/graph.shell.test-web.gv
+++ b/test/test-resources/graph.shell.test-web.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -18,7 +17,7 @@ height=0"]
 	}
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1604
@@ -37,7 +36,7 @@ height=1"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
 dmake-test/test-worker:ubuntu-1604
@@ -49,14 +48,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=2"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume
@@ -72,7 +71,7 @@ height=0"]
 	"('shell', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))"
 	"('shell', 'dmake-test/test-web', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('shell', 'dmake-test/test-web', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group shell" {
 		rank=same
 		"('shell', 'dmake-test/test-web', None)" [label="shell
 dmake-test/test-web

--- a/test/test-resources/graph.shell.test-web.gv
+++ b/test/test-resources/graph.shell.test-web.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=2"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1604::base
 None
@@ -65,7 +65,7 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 	"('shell', 'dmake-test/test-web', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('shell', 'dmake-test/test-web', None)" -> "('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))"

--- a/test/test-resources/graph.test.*.gv
+++ b/test/test-resources/graph.test.*.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=2"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1604::base
 None
@@ -26,11 +26,11 @@ height=0"]
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
 None
-height=5"]
+height=0"]
 		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
 dmake-test/test-external-dependency-nginx
 None
-height=3"]
+height=0"]
 		"('build_docker', 'dmake-test/test-gpu', None)" [label="build_docker
 dmake-test/test-gpu
 None
@@ -42,11 +42,11 @@ height=0"]
 		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
 dmake-test/test-web
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-worker2', None)" [label="build_docker
 dmake-test/test-worker2
 None
@@ -89,11 +89,11 @@ height=1"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx2)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
 dmake-test/test-web
 test-web (web)
@@ -101,7 +101,7 @@ height=5"]
 		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
 dmake-test/test-web2
 test-web2 (web2)
-height=5"]
+height=4"]
 		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
 dmake-test/test-worker:ubuntu-1604
 test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
@@ -128,7 +128,7 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
 	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
@@ -163,7 +163,7 @@ height=6"]
 		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
 dmake-test/test-external-dependency-nginx
 None
-height=4"]
+height=1"]
 		"('test', 'dmake-test/test-gpu', None)" [label="test
 dmake-test/test-gpu
 None
@@ -179,7 +179,7 @@ height=4"]
 		"('test', 'dmake-test/test-web2', None)" [label="test
 dmake-test/test-web2
 None
-height=4"]
+height=2"]
 		"('test', 'dmake-test/test-worker2', None)" [label="test
 dmake-test/test-worker2
 None

--- a/test/test-resources/graph.test.*.gv
+++ b/test/test-resources/graph.test.*.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -21,7 +20,7 @@ height=0"]
 	"('build_docker', 'dmake-test/test-worker2', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
@@ -84,7 +83,7 @@ height=1"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
@@ -112,14 +111,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=3"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume
@@ -154,7 +153,7 @@ height=0"]
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group test" {
 		rank=same
 		"('test', 'dmake-test/test-e2e', None)" [label="test
 dmake-test/test-e2e

--- a/test/test-resources/graph.test.test-e2e.gv
+++ b/test/test-resources/graph.test.test-e2e.gv
@@ -6,7 +6,7 @@ digraph {
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
 None
-height=2"]
+height=0"]
 		"('base', 'dmake-test-worker-base_ubuntu-1604__base', None)" [label="base
 dmake-test-worker-base:ubuntu-1604::base
 None
@@ -25,19 +25,19 @@ height=0"]
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
 None
-height=5"]
+height=0"]
 		"('build_docker', 'dmake-test/test-external-dependency-nginx', None)" [label="build_docker
 dmake-test/test-external-dependency-nginx
 None
-height=3"]
+height=0"]
 		"('build_docker', 'dmake-test/test-web', None)" [label="build_docker
 dmake-test/test-web
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
 None
-height=3"]
+height=1"]
 		"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" [label="build_docker
 dmake-test/test-worker:ubuntu-1604
 None
@@ -76,11 +76,11 @@ height=1"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx2', env=[], env_exports=[]))" [label="run
 dmake-test/test-external-dependency-nginx
 test-external-dependency-nginx (nginx2)
-height=5"]
+height=2"]
 		"('run', 'dmake-test/test-web', NeededServiceSerializer(service_name='test-web', link_name='web', env=[], env_exports=['WEB_URL']))" [label="run
 dmake-test/test-web
 test-web (web)
@@ -88,7 +88,7 @@ height=5"]
 		"('run', 'dmake-test/test-web2', NeededServiceSerializer(service_name='test-web2', link_name='web2', env=[], env_exports=['WEB2_URL']))" [label="run
 dmake-test/test-web2
 test-web2 (web2)
-height=5"]
+height=4"]
 		"('run', 'dmake-test/test-worker_ubuntu-1604', NeededServiceSerializer(service_name='test-worker_ubuntu-1604', link_name=None, env=['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'], env_exports=[]))" [label="run
 dmake-test/test-worker:ubuntu-1604
 test-worker:ubuntu-1604 -- env: ['ENV_OVERRIDE_TEST3', 'ENV_OVERRIDE_TEST5', 'TEST_ENV_OVERRIDE', 'TEST_SHARED_VOLUME'] -- env_exports: []
@@ -115,7 +115,7 @@ height=0"]
 		"('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)" [label="shared_volume
 shared_volume_web_and_workers::shared_volume
 None
-height=1"]
+height=0"]
 	}
 	"('test', 'dmake-test/test-e2e', None)" -> "('build_docker', 'dmake-test/test-e2e', None)"
 	"('test', 'dmake-test/test-e2e', None)" -> "('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))"
@@ -147,7 +147,7 @@ height=6"]
 		"('test', 'dmake-test/test-external-dependency-nginx', None)" [label="test
 dmake-test/test-external-dependency-nginx
 None
-height=4"]
+height=1"]
 		"('test', 'dmake-test/test-web', None)" [label="test
 dmake-test/test-web
 None
@@ -155,7 +155,7 @@ height=4"]
 		"('test', 'dmake-test/test-web2', None)" [label="test
 dmake-test/test-web2
 None
-height=4"]
+height=2"]
 		"('test', 'dmake-test/test-worker_ubuntu-1604', None)" [label="test
 dmake-test/test-worker:ubuntu-1604
 None

--- a/test/test-resources/graph.test.test-e2e.gv
+++ b/test/test-resources/graph.test.test-e2e.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -20,7 +19,7 @@ height=0"]
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1604', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1604__base', None)"
 	"('build_docker', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('base', 'dmake-test-worker-base_ubuntu-1804__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-e2e', None)" [label="build_docker
 dmake-test/test-e2e
@@ -71,7 +70,7 @@ height=1"]
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
 	"('run', 'dmake-test/test-worker_ubuntu-1804', NeededServiceSerializer(service_name='test-worker_ubuntu-1804', link_name='worker-ubuntu-1804', env=['TEST_SHARED_VOLUME'], env_exports=[]))" -> "('test', 'dmake-test/test-worker_ubuntu-1804', None)"
-	{
+	subgraph "group run" {
 		rank=same
 		"('run', 'dmake-test/test-external-dependency-nginx', NeededServiceSerializer(service_name='test-external-dependency-nginx', link_name='nginx', env=[], env_exports=['NGINX_URL']))" [label="run
 dmake-test/test-external-dependency-nginx
@@ -99,14 +98,14 @@ test-worker:ubuntu-1804 (worker-ubuntu-1804) -- env: ['TEST_SHARED_VOLUME'] -- e
 height=3"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume
@@ -138,7 +137,7 @@ height=0"]
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
 	"('test', 'dmake-test/test-worker_ubuntu-1804', None)" -> "('shared_volume', 'shared_volume_web_and_workers__shared_volume', None)"
-	{
+	subgraph "group test" {
 		rank=same
 		"('test', 'dmake-test/test-e2e', None)" [label="test
 dmake-test/test-e2e

--- a/test/test-resources/graph.test.test-web2.gv
+++ b/test/test-resources/graph.test.test-web2.gv
@@ -1,7 +1,6 @@
 // DMake Services
 digraph {
-	node [shape=box]
-	{
+	subgraph "group base" {
 		rank=same
 		"('base', 'dmake-test-web-base__base', None)" [label="base
 dmake-test-web-base::base
@@ -9,7 +8,7 @@ None
 height=0"]
 	}
 	"('build_docker', 'dmake-test/test-web2', None)" -> "('base', 'dmake-test-web-base__base', None)"
-	{
+	subgraph "group build_docker" {
 		rank=same
 		"('build_docker', 'dmake-test/test-web2', None)" [label="build_docker
 dmake-test/test-web2
@@ -17,14 +16,14 @@ None
 height=1"]
 	}
 	"('run_link', 'links/dmake-test/rabbitmq', None)" -> "('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)"
-	{
+	subgraph "group run_link" {
 		rank=same
 		"('run_link', 'links/dmake-test/rabbitmq', None)" [label="run_link
 links/dmake-test/rabbitmq
 None
 height=1"]
 	}
-	{
+	subgraph "group shared_volume" {
 		rank=same
 		"('shared_volume', 'shared_rabbitmq_var_lib__shared_volume', None)" [label="shared_volume
 shared_rabbitmq_var_lib::shared_volume
@@ -33,7 +32,7 @@ height=0"]
 	}
 	"('test', 'dmake-test/test-web2', None)" -> "('build_docker', 'dmake-test/test-web2', None)"
 	"('test', 'dmake-test/test-web2', None)" -> "('run_link', 'links/dmake-test/rabbitmq', None)"
-	{
+	subgraph "group test" {
 		rank=same
 		"('test', 'dmake-test/test-web2', None)" [label="test
 dmake-test/test-web2

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -24,6 +24,7 @@ def generate_resources_graph(test_list = graph_test_list):
         subprocess.call([
             'dmake',
             '--debug-graph-and-exit',
+            '--no-debug-graph-pretty',
             '--debug-graph-output-filename={}'.format(expected_dot_path),
             command, service
         ], cwd=path)
@@ -39,6 +40,7 @@ def test_graph(command, service):
     common.generate_dot_graph = True
     common.exit_after_generate_dot_graph = True
     common.dot_graph_group_by = 'command'
+    common.dot_graph_pretty = False
     common.dot_graph_filename = None
     dot = core.make(args)
 

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -38,6 +38,7 @@ def test_graph(command, service):
     common.sub_dir = 'test'  # to test '*' for only 'test/'
     common.generate_dot_graph = True
     common.exit_after_generate_dot_graph = True
+    common.dot_graph_group_by = 'command'
     common.dot_graph_filename = None
     dot = core.make(args)
 


### PR DESCRIPTION
# Goal: faster CI by executing dmake steps in parallel when possible

This MVP only works on Jenkins, where we have higher-level primitives, and more resources control.

Enable it via `DMAKE_PARALLEL_EXECUTION = 1` environment variable.

# Results
test:`dmake test \*`, with base image and image already in cache, a.k.a. worst case for easy parallel gains (docker builds are all parallelizable)

Full command when debugging this:
```
DMAKE_PARALLEL_EXECUTION=1 CHANGE_BRANCH=master DMAKE_ON_BUILD_SERVER=1 dmake --debug-graph-and-exit --debug-graph-pretty --debug-graph-group-by height deploy \*
```
- `DMAKE_PARALLEL_EXECUTION=1` to enable parallel execution
- `CHANGE_BRANCH=master` to fake Jenkins environment (i.e. a PR to be merged into `master` branch), so it generates with Jenkinsfile instead of bash format (which would fail as parallel is not supported there)
- `DMAKE_ON_BUILD_SERVER=1` to generate the DMakefile and stop there, without executing it
- `--debug-graph-and-exit`: generate debug graph, then exit, skipping plan/DMakefile generation (some of the previous options are thus useless in this narrow case)
- `--debug-graph-pretty` to have pretty visual formatting of the graph (that's new, and that's the default)
- `--debug-graph-group-by height` to generate a debug graph ranked by height: each line is a a parallel execution bloc
- `deploy \*` to have the complete graph with `deploy`

How to read images:
- jenkins blue ocean: displays the sequence of parallel executions from left to right
- dmake debug graph: each node with the real dependencies as arrows, nodes of same height are positioned on the same line: each line is executed in parallel (starting from bottom)

## dmake: 2min15s -> 1min30s
https://build.deepomatic.com/blue/organizations/jenkins/dmake/detail/PR-472/12/pipeline
![dmake jenkins blue ocean](https://user-images.githubusercontent.com/1730297/103909210-b6e2ca00-5103-11eb-99ca-55473011491a.png)
![dmake dmake-services debug height gv](https://user-images.githubusercontent.com/1730297/103909251-c19d5f00-5103-11eb-9b32-1d96f4346ace.png)
![dmake dmake-services debug height pretty deploy gv](https://user-images.githubusercontent.com/1730297/107633220-f606bc80-6c67-11eb-86dd-176480684945.png)

See https://github.com/Deepomatic/squad-infra-deploy/issues/90#issuecomment-756180208 for more information, tests on internal repositories, etc.

# Details
Some preliminary work was done in #474

More preliminary work:
- New height: ASAP vs ALAP; Add --debug-graph-group-by option: optionally sort by height
- Valid generated Jenkinsfiles checks moved into generate_command_pipeline
- Fix uniqueness of NeededService name suffix

Real work:
- Parallel execution by height, with global Jenkins machine resource lock to try to avoid saturating resources (mainly RAM)
- Parallel deploy all services, after all the other nodes (without resource lock to avoid potential kubernetes deployment deadlocks), to avoid half deploying an app if an independent service test fails.

Building blocks:
- use `parallel()` which runs multiple branches of code in parallel,
  in one common executor
  Limitation: need static definition of parallel branches, Jenkins
  doesn't support dynamic generation of branches :-(
- use `lock(PARALLEL_BUILDERS)` to globally limit parallelism on the
  whole Jenkins machine, across jobs, to limit resource
  saturation (mainly RAM)
Locking in a parallel branch doesn't use any (scarce) resource, so the
pattern of `parallel+lock` is OK.

As an MVP, we executes nodes of same height in parallel: the global
execution is a sequence of parallel executions of steps of same
height.
This is not optimal but:
- we cannot reach optimal solution with static scheduling and unknown
  tasks duration,
- it works by construction, nodes depend (directly or indirectly) on
  nodes of strictly lower height, so same height are guaranteed to be
  independent: we can execute them in parallel
- and it gives some notable gains on standard patterns:
  - `base_build` then `build` steps are executed in parallel
  - `needed_links` are started as soon as possible: while the rest
    is built
  - with any luck, some tests are executed in parallel

Later versions could implement some heuristics, maybe detect
independent sub-graphs after having removed base_build and build,
i.e. for run and test, and execute them in parallel (nested
`parallel()`, it works).

From the user point-of-view, we display the standard ordered Plan, by
command, then, as a second pass, display (and dump) the new parallel
plan, by height.

Special case: all `deploy` nodes are executed in parallel, after
everything else (and without resource lock): we don't want to start
deploying some services of an app while other services are still being
tested: their tests could fail and we don't want a partially deployed
app.
Don't lock PARALLEL_BUILDERS on deploy height, it could lead to
deployment deadlock if there is a deployment runtime dependancy
between services.
Caveat: the height on the debug graph is thus wrong in regard to the
parallel execution; it was to much hack to have the graph with
"new/faked" height as in parallel execution while *not* changing
anything to the initial/default Plan.

Implementation-wise, we generate the commands for each node only once:
in the first, default, pass, as before; additionally, we now store
them in a new `nodes_commands[node]` dict.
This is reused in the second pass to re-order by height, and wrap with
`parallel()` and `lock()`.
For the regrouping of `deploy` nodes, we just extract them while
constructing the `nodes_by_height` dict, and inject them back at the
end on a new height.

Special care is taken on GPU lock to start locking it as late as
possible, but since the nodes are now executed as soon as possible, we
may see more GPU contention.
We cannot unlock GPU before the very end of the dmake execution
because there is no notion of `run_stop` for now (we could stop and
unlock gpu before deploying for example)

Visually on Jenkins:

Classic UI:
- logs are prefixed by the parallel branch name
  e.g. `[base @ dmake-test-web-base::base]`
- `Pipeline Steps` show a tree representation, with stage and ~step
  names, durations, and access to log for each step

Blue Ocean:
- the sequence of parallel branches is displayed \o/
- parallel blocs labels are not displayed :-(
- each node is labeled, and clickable to get steps logs
- parallel blocs with zero branches are skipped (otherwise Jenkins
  raises an error)
- parallel blocs with one branch are emitted as such, but create
  graphical glitch on blue ocean with our current jenkins version: the
  node is not visible during the build; but after the job has
  finished, it is visible
  (I tried to emit a stage without `parallel()` in such case, but a
  worse bug happened: the node disappeared not during but after the
  build...)

# Followup
- [ ] use heuristics: parallel `build_base` and `build` is good, but by excluding them independent sub-graphs could be extracted and executed in parallel (nested parallel), effectively working on run+test commands only at that point (it will probably be time to switch to `networkx`); try to optimize for future unit-test+e2e pattern
- [ ] maybe implement for local execution too? using gnu `parallel`? careful with parallelism: resources can be more scarce on developers machines
- [ ] maybe split `deploy` into `publish` and `deploy` (`docker push` and `kubectl apply`): publish can be done with resources lock, only `kubectl apply` needs to be done in parallel to avoid locks. Maybe regroup them into one deploy node per app?