### PR TITLE
Fix argcompletion shell code generation

### DIFF
--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -22,7 +22,7 @@ def add_argument(parsers, *args, **kwargs):
 
 
 def completion_action(args):
-    print(argcomplete.shellcode('dmake', shell=args.shell))
+    print(argcomplete.shellcode(['dmake'], shell=args.shell))
 
 
 # Find root


### PR DESCRIPTION
Regression introduced by c37cd68055cf2b54e658067c0e87f9cb182c5d40,
which bumped argcompletion, which included an undocumented breaking
change (https://github.com/kislyuk/argcomplete/pull/246) that lead to
generating `d m a k e` instead of `dmake` in the final bash script,
breaking the completion (and maybe other things).

How to update (run from a directory containing a dmake project to avoid `Current directory is not a Git repository` error):
```
rm  "${DMAKE_CONFIG_DIR:-$HOME/.dmake}/completion.bash.inc"  
dmake completion > "${DMAKE_CONFIG_DIR:-$HOME/.dmake}/completion.bash.inc" 
source "${DMAKE_CONFIG_DIR:-$HOME/.dmake}/completion.bash.inc" 
```
(see `dmake completion --help` for other shells than bash)