### PR TITLE
Pin bootstrap.pypa.io pip installer for specific python versions, the default one now requires python 3.6+

### DIFF
--- a/dmake/templates/docker-base/install_pip.sh
+++ b/dmake/templates/docker-base/install_pip.sh
@@ -9,5 +9,5 @@
 if [ `which pip | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python-setuptools python-dev libffi-dev libssl-dev curl g++
-    curl https://bootstrap.pypa.io/get-pip.py | python - pip==9.0.3
+    curl https://bootstrap.pypa.io/2.7/get-pip.py | python - pip==9.0.3
 fi

--- a/dmake/templates/docker-base/install_pip3.sh
+++ b/dmake/templates/docker-base/install_pip3.sh
@@ -9,5 +9,5 @@
 if [ `which pip3 | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python3-setuptools python3-dev libffi-dev libssl-dev curl g++
-    curl https://bootstrap.pypa.io/get-pip.py | python3 - pip==9.0.3
+    curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 - pip==9.0.3
 fi


### PR DESCRIPTION
Later: just drop these features

See https://github.com/pypa/get-pip/issues/29 for more context.