### PR TITLE
Faster dmake auto-completion via faster imports (lazy): 270ms->110ms

### DIFF
--- a/dmake/commands/release.py
+++ b/dmake/commands/release.py
@@ -1,10 +1,8 @@
 import os
 
 import dmake.common as common
-import inquirer
 import semver
 from dmake.common import DMakeException
-from github import Github
 
 
 def remove_tag_prefix(tag):
@@ -62,6 +60,10 @@ def is_valid_bump(prev_version, next_version):
 
 
 def entry_point(options):
+    # lazy import for faster cli
+    from github import Github
+    import inquirer
+
     app = getattr(options, 'app')
     release_tag = getattr(options, 'tag')
 

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -5,13 +5,11 @@ import json
 import uuid
 import importlib
 import re
-import requests.exceptions
 from string import Template
 from dmake.serializer import ValidationError, FieldSerializer, YAML2PipelineSerializer, SerializerType
 import dmake.common as common
 from dmake.common import DMakeException, SharedVolumeNotFoundException, append_command
 import dmake.kubernetes as k8s_utils
-import dmake.docker_registry as docker_registry
 from dmake.docker_image import DockerImageFieldSerializer
 
 ###############################################################################
@@ -225,6 +223,10 @@ class DockerBaseSerializer(YAML2PipelineSerializer):
         return result
 
     def _serialize_(self, commands, path_dir):
+        # lazy import for faster cli
+        import requests.exceptions
+        import dmake.docker_registry as docker_registry
+
         # Make the temporary directory
         tmp_dir = common.make_tmp_dir('base_image_{name}'.format(name=common.sanitize_name(self.name)))
 

--- a/dmake/kubernetes.py
+++ b/dmake/kubernetes.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import yaml
 
 import dmake.common as common
 
@@ -14,7 +13,7 @@ def get_env_hash(env):
 
 def generate_config_map(env, name, labels = None, annotations = None):
     """Return a kubernetes manifest defining a ConfigMap storing `env`."""
-    data = yaml.safe_load("""
+    data = common.yaml_ordered_load("""
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -38,7 +37,7 @@ def generate_config_map_file(env, name_prefix, output_filepath, labels = None, a
     name = "%s-env-%s" % (name_prefix, env_hash)
     data = generate_config_map(env, name, labels, annotations)
     with open(output_filepath, 'w') as configmap_file:
-        yaml.dump(data, configmap_file, default_flow_style=False)
+        common.yaml_ordered_dump(data, configmap_file, default_flow_style=False)
     return name
 
 


### PR DESCRIPTION
- lazy import some large and uncommon modules
- don't use both yaml and ruamel.yaml: normalize on the later via dmake.common

How to benchmark:
```
$ time _ARGCOMPLETE_SUPPRESS_SPACE=1 COMP_LINE='dmake shell ' COMP_POINT=12 COMP_TYPE=63 _ARGCOMPLETE=0 dmake 
$ time python3 -c 'import dmake.cli'
$ time python3 -X importtime -c 'import dmake.cli' |& sort -k5g
```
