### PR TITLE
Don't invalidate base image build cache when fixing largely unused `python_requirements`

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -274,7 +274,11 @@ class DockerBaseSerializer(YAML2PipelineSerializer):
             template_files = ["make_base.sh"]
         else:
             template_dir = "docker-base"
-            template_files = ["make_base.sh", "config.logrotate", "load_credentials.sh", "install_pip.sh", "install_pip3.sh"]
+            template_files = ["make_base.sh", "config.logrotate", "load_credentials.sh"]
+            if self.python_requirements:
+                template_files.append("install_pip.sh")
+            if self.python3_requirements:
+                template_files.append("install_pip3.sh")
 
         for template_file in template_files:
             md5s[template_file] = common.run_shell_command('%s dmake_copy_template %s %s' % (local_env, os.path.join(template_dir, template_file), os.path.join(tmp_dir, template_file)))


### PR DESCRIPTION
1df5824fb7b0a044e1cb894d17ab866a33b55762 / #477 fixed the scripts
behind `python_requirements` (and `python3_requirements`), which were
deprecated a long long time ago (see #77).

Sadly, in doing so, the md5 of the base image source changed, because
these scripts were always added to the base image, even when unused.
This resulted in user visible issue: invalidation of all base images,
for nothing, since this feature is (almost) not used.

The end-goal is to remove that altogether, but in the meantime we can
avoid a double base image hash change by anticipating that end-goal,
while still keeping the feature working for now: don't emit these
files when they are not needed.