### PR TITLE
Collect tests results even when some tests fail (or timeout) 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ node {
     dir('workspace') {
       if (self_test) {
         try {
-          sh ". .venv3/bin/activate && pytest -vv --junit-xml=junit.xml --junit-prefix=python3"
+          sh ". .venv3/bin/activate && pytest -vv --color=yes --junit-xml=junit.xml --junit-prefix=python3"
         } finally {
           junit keepLongStdio: true, testResults: 'junit.xml'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,8 +97,11 @@ node {
     sh "rm workspace/.venv3/bin/python" // remove python to detect illegitime usage of python (which is often python2)
     dir('workspace') {
       if (self_test) {
-        sh ". .venv3/bin/activate && pytest -vv --junit-xml=junit.xml --junit-prefix=python3"
-        junit keepLongStdio: true, testResults: 'junit.xml'
+        try {
+          sh ". .venv3/bin/activate && pytest -vv --junit-xml=junit.xml --junit-prefix=python3"
+        } finally {
+          junit keepLongStdio: true, testResults: 'junit.xml'
+        }
       }
       if (params.DMAKE_COMMAND == 'test') {
         echo "First: kubernetes deploy dry-run (just plan deployment on target branch to validate kubernetes manifests templates)"

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -132,6 +132,14 @@ def append_command(commands, cmd, prepend = False, **args):
         check_cmd(args, ['time'])
     elif cmd == "timeout_end":
         check_cmd(args, [])
+    elif cmd == "try":
+        check_cmd(args, [])
+    elif cmd == "catch":
+        check_cmd(args, ['what'])
+    elif cmd == "throw":
+        check_cmd(args, ['what'])
+    elif cmd == "catch_end":
+        check_cmd(args, [])
     elif cmd == "echo":
         check_cmd(args, ['message'])
     elif cmd == "sh":

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -499,7 +499,7 @@ def generate_command_pipeline(file, cmds):
 
     if common.build_description is not None:
         write_line("currentBuild.description = '%s'" % common.build_description.replace("'", "\\'"))
-    write_line("def dmake_echo(message) { sh(script: \"echo $message\", label: message) }")
+    write_line("def dmake_echo(message) { sh(script: \"echo '${message}'\", label: message) }")
     write_line('try {')
     indent_level += 1
 

--- a/dmake/utils/dmake_run_docker_test
+++ b/dmake/utils/dmake_run_docker_test
@@ -27,7 +27,12 @@ shift 2
 
 TMP_DIR=$(dmake_make_tmp_dir "${SERVICE_NAME/\//-}")
 
+set +e
 dmake_run_docker "" "${NAME}" --cidfile ${TMP_DIR}/cid.txt "$@"
+# always store container id in txt files, even if tests failed
+ret=$?
+set -e
+
 CONTAINER_ID=$(cat ${TMP_DIR}/cid.txt)
 
 if [ ! -z "${SERVICE_NAME}" ]; then
@@ -35,3 +40,5 @@ if [ ! -z "${SERVICE_NAME}" ]; then
 fi
 
 echo ${CONTAINER_ID} >> ${DMAKE_TMP_DIR}/containers_to_remove.txt
+
+exit $ret

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -79,7 +79,16 @@ services:
           --with-xunit --xunit-file nosetests.xml
           --nologcapture
           --with-id
-      junit_report: nosetests.xml
+        #- lets_fail_here
+        - >-
+          ./manage.py test
+          --verbosity=2 --noinput
+          --with-xunit --xunit-file nosetests2.xml
+          --nologcapture
+          --with-id
+      junit_report:
+        - nosetests.xml
+        - nosetests2.xml
       html_report:
         directory: cover/
         title: Web HTML coverage report


### PR DESCRIPTION
closes #374

## Collect tests results even when some tests fail (or timeout) 
Tricky case: when tests failed, some tests may have not been executed,
so tests results files may be missing.
We still want to collect them if possible, without raising extra error
if we cant.
We still want to fail when the collection failed when the tests
succeeded though.

Current solution: duplicate the tests results collections commands,
wrap tests, and individual collections, with try/catch/rethrow and
help messages.

On bash, use https://stackoverflow.com/a/25180186/15151442 for
try/catch.

Maybe a better way to handle that would be to have a "super cmd" that
takes the individual test results collections cmds, and handle the
error handling and duplication in generate_command_bash|pipeline()?

Also:
- always store container id in txt files, even if tests failed
- always late-collect cobertura reports.
We reach that point either via normal flow where we do want an error
if no file found, or via test error where we don't want an error if no
file found.
Luckily, inline part of cobertura will already have failed if file is
missing; with proper error handling: we can ignore all that here.

To test things, uncomment `#- lets_fail_here` in testweb/dmake.yml


## Results
https://build.deepomatic.com/job/dmake/job/PR-482/20
Here is how it looks like when a test fails, with remaining tests results to collect (and DMAKE_DEBUG=1, it's less verbose in real life):
in classic logs: `Failed in branch test @ dmake-test/test-web`

in blue ocean:
![blue ocean graph](https://user-images.githubusercontent.com/1730297/108886979-ebeea180-7609-11eb-821e-e4c224bf4e69.png)

![blue ocean steps logs](https://user-images.githubusercontent.com/1730297/108886793-b053d780-7609-11eb-94fd-c91e68b6bf83.png)

## Also
- Jenkins collect dmake self tests results even on error 
- Add color to dmake self tests output 
-  quickfix escaping echo messages containing `;`
  We probably need more escaping: bash escaping, but the generate_bash
  echo escaping is also wrong (it uses groovy string escaping, not bash
  escaping...), so it's even between bash and jenkinsfile generation.
-  Add indentation to bash generated DMakefile, like it's already done for Jenkinsfile