### PR TITLE
Add needed_services[].use_host_ports

### DIFF
--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -1074,6 +1074,7 @@ class NeededServiceSerializer(YAML2PipelineSerializer):
     env             = FieldSerializer("dict", child = "string", optional = True, default = {}, help_text = "List of environment variables that will be set when executing the needed service.", example = {'CNN_ID': '2'})
     env_exports     = FieldSerializer("dict", child = "string", default = {}, help_text = "A set of environment variables that will be exported in services that use this service when testing.")
     needed_for      = NeededForSerializer(help_text = "When is this dependency service needed for?")
+    use_host_ports  = FieldSerializer("bool", optional = True, help_text = "Set to false to disable exposing internal dependency service ports on host, without impacting his feature when that service is directly started.")
 
     def __init__(self, **kwargs):
         super(NeededServiceSerializer, self).__init__(**kwargs)
@@ -1394,6 +1395,7 @@ class DMakeFile(DMakeFileSerializer):
         unique_service_name = service_name
         additional_customization_env_variables = {}
         link_name = None
+        use_host_ports = None
         if service_customization:
             # customization variables will be evaluated later:
             #   by `env.get_replaced_variables()` in the wrong dmake file runtime `.env`, but sometimes OK thanks to needed_links env_exports
@@ -1402,8 +1404,9 @@ class DMakeFile(DMakeFileSerializer):
             # daemon name: <app_name>/<service_name><optional_unique_suffix>; service_name already contains "<app_name>/"
             unique_service_name += service_customization.get_service_name_unique_suffix()
             link_name = service_customization.link_name
+            use_host_ports = service_customization.use_host_ports
 
-        docker_opts, image_name, env = self._generate_run_docker_opts_(commands, service, docker_links, dependencies_needed_for='run', additional_env_variables=additional_customization_env_variables)
+        docker_opts, image_name, env = self._generate_run_docker_opts_(commands, service, docker_links, dependencies_needed_for='run', additional_env_variables=additional_customization_env_variables, use_host_ports=use_host_ports)
         docker_opts += service.tests.get_mounts_opt(service_name, self.__path__, env)
         docker_cmd = 'dmake_run_docker_daemon "%s" "%s" "%s" "" %s -i %s' % (self.app_name, unique_service_name, link_name or "", docker_opts, image_name)
         docker_cmd = service.get_docker_run_gpu_cmd_prefix() + docker_cmd

--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -3,6 +3,15 @@
 !worker/
 !web/
 
+**/*~
+**/.#*
+
+# web/ ignores
+web/cover/
+web/coverage.xml
+web/nosetests.xml
+
+
 # worker/ ignores
 worker/dmake.yml
 worker/.dmake/

--- a/test/web/dmake.yml
+++ b/test/web/dmake.yml
@@ -40,6 +40,7 @@ services:
           TEST_ENV_OVERRIDE: "1"
           ENV_OVERRIDE_TEST3: from_needed_service_env
           ENV_OVERRIDE_TEST5: from_needed_service_env
+        use_host_ports: false
       - service_name: test-worker:ubuntu-1804
         link_name: worker-ubuntu-1804
         env:

--- a/test/worker/.dockerignore
+++ b/test/worker/.dockerignore
@@ -4,3 +4,6 @@ dmake.yml
 deploy/Dockerfile
 
 bin/
+
+**/*~
+**/.#*

--- a/test/worker/dmake.yml
+++ b/test/worker/dmake.yml
@@ -68,6 +68,9 @@ services:
             com.deepomatic.version.is-on-premises: "false"
             build-host: "${HOSTNAME}"
           target: runtime
+      ports:
+        - container_port: 8001
+          host_port: 9001
       env_override:
         ENV_OVERRIDE_TEST2: from_env_override
         ENV_OVERRIDE_TEST3: from_env_override


### PR DESCRIPTION
Useful to force disable host_port when a service is used as a
dependency, and still keep this available when that service is
directly started; for example a frontend, also started as a dependency
of the backend, to support front, back, and both-together development
modes.

Add useless host_port and use_host_ports usage in test/*/dmake.yml to
cover that part.

This doesn't properly cover all edge cases regarding NeededService
specialization: we assume all instances for a service that are
otherwise identical are using the same value for
`use_host_ports`. It's undefined behavior to not do that.

Also improve test/*/.dockerignore for faster tests.