### PR TITLE
Fix dmake_test_get_results on non-empty target dir, i.e. on local machine

### DIFF
--- a/dmake/utils/dmake_test_get_results
+++ b/dmake/utils/dmake_test_get_results
@@ -34,5 +34,6 @@ if [ -z "${LINE}" ]; then
 fi
 CONTAINER_ID=`echo ${LINE} | cut -d\  -f 1`
 
-mkdir -p $(dirname ${DEST_PATH})
-docker cp ${CONTAINER_ID}:${SRC_PATH} ${DEST_PATH}
+PARENT_DEST_PATH=$(dirname ${DEST_PATH})
+mkdir -p ${PARENT_DEST_PATH}
+docker cp ${CONTAINER_ID}:${SRC_PATH} ${PARENT_DEST_PATH}


### PR DESCRIPTION
running locally tests 2 times results in unexpected result:
docker cp mycontainer:/app/cover/ cover/
cover/ is ok

second run:
docker cp mycontainer:/app/cover/ cover/
cover/cover/ is created, it should not exist

(it happens with `dmake test \*` on dmake repo for `test/web/cover/`)

For files and not directory it already worked OK because nesting is
not possible.

solution: docker cp on parent path is idempotent.

On jenkins we always create a unique temporary directory, so there is
never a 'second run' on an existing target directory: that's why we
never saw any issue on test results collection on jenkins.