### PR TITLE
Fix bash invalid syntax error on empty stage

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -722,8 +722,7 @@ function ignoreErrors()
     for cmd, kwargs in cmds:
         if cmd == "stage":
             write_line("")
-            write_line("echo -e '\n## %s ##'" % kwargs['name'])
-            write_line("{")
+            write_line("{ echo -e '\n## %s ##'" % kwargs['name'])
             indent_level += 1
         elif cmd == "stage_end":
             indent_level -= 1


### PR DESCRIPTION
Fix regression introduced by 2d00408a8274ea3bc63d2a9de6142fc4481afe41

Bash doesn't like:
```
echo -e '
## Building App ##'
{
}
```
=> DMakefile: line 56: syntax error near unexpected token `}'

Solution: guarantee at lest one command is in the block: the stage name echo
```
{ echo -e '
## Building App ##'
}
```