### PR TITLE
Fix cobertura_report collection error because of earlier error, before tests

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -664,9 +664,15 @@ def generate_command_pipeline(file, cmds):
     indent_level += 1
 
     if emit_cobertura:
+        write_line("try {")
+        indent_level += 1
         write_line("step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '%s/**/*.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])" % (cobertura_tests_results_dir))
         write_line("publishCoverage adapters: [coberturaAdapter(mergeToOneReport: true, path: '%s/**/*.xml')], calculateDiffForChangeRequests: true, sourceFileResolver: sourceFiles('NEVER_STORE')" % (cobertura_tests_results_dir))
         write_line('''sh('rm -rf "%s"')''' % cobertura_tests_results_dir)
+        indent_level -= 1
+        write_line("} catch (error) {")
+        write_line("  dmake_echo 'Late cobertura_report test result collection failed, it may be because the test steps were not reached (earlier error: check logs/steps above/before), or because the cobertura_report is misconfigured (check the path config).'")
+        write_line("}")
 
     write_line('sh("dmake_clean")')
     indent_level -= 1


### PR DESCRIPTION
CoberturaPublisher is done at the end of the execution because it
cannot be duplicated (at least it was the case several years ago when
it was plugged-in).

With 1f3c17db399c85e923e5506e1c3d33636473bb57 / #482 we tried to
eagerly collect tests results even when tests failed, but didn't
properly handle that late collection in the case of errors before any
test step: the tests results won't exist.

Because it's a global, late collection, we cannot do the fancy double
collection with/without error propagation that we did in #482 for the
other tests results collections.
That's OK; the situation is explained to the user.