### PR TITLE
Fix curl get-pip that they broke again...

### DIFF
--- a/dmake/templates/docker-base/install_pip.sh
+++ b/dmake/templates/docker-base/install_pip.sh
@@ -9,5 +9,5 @@
 if [ `which pip | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python-setuptools python-dev libffi-dev libssl-dev curl g++
-    curl https://bootstrap.pypa.io/2.7/get-pip.py | python - pip==9.0.3
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python - pip==9.0.3
 fi

--- a/dmake/templates/docker-base/install_pip3.sh
+++ b/dmake/templates/docker-base/install_pip3.sh
@@ -9,5 +9,5 @@
 if [ `which pip3 | wc -l` = "0" ]; then
     echo "N" | apt-get --no-install-recommends -y install openssh-client
     apt-get --no-install-recommends -y install python3-setuptools python3-dev libffi-dev libssl-dev curl g++
-    curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 - pip==9.0.3
+    curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 - pip==9.0.3
 fi


### PR DESCRIPTION
After their breaking change we fixed in #477, they broke again to add `pip/` in the URL:
```

Hi there!

The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!

We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.

There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.

Thanks for understanding!

- Pradyun, on behalf of the volunteers who maintain pip.
```

I could not find more documentation about that in https://pip.pypa.io/en/stable/installing/