### PR TITLE
Better message when an error occurred

### DIFF
--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -49,7 +49,7 @@ subparsers.required = True
 parser_test    = subparsers.add_parser('test', help="Launch tests for the whole repo or, if specified, an app or one of its services.")
 parser_build   = subparsers.add_parser('build', help="Launch the build for the whole repo or, if specified, an app or one of its services.")
 parser_run     = subparsers.add_parser('run', help="Launch the application or only one of its services.")
-parser_stop    = subparsers.add_parser('stop', help="Stop the containers lauched with 'dmake run'.")
+parser_stop    = subparsers.add_parser('stop', help="Stop the containers started by dmake for the current repository and branch. Usually by 'dmake run', but can also be useful to cleanup aborted executions of dmake.")
 parser_shell   = subparsers.add_parser('shell', help="Run a shell session withing a docker container with the environment set up for a given service.")
 parser_deploy  = subparsers.add_parser('deploy', help="Deploy specified apps and services.")
 parser_release = subparsers.add_parser('release', help="Create a release of the app on Github.")

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -1214,9 +1214,18 @@ def make(options, parse_files_only=False):
         # Do not clean for the 'run' command
         do_clean = common.command not in ['build_docker', 'run']
         if result != 0 and common.command in ['shell', 'test']:
-            r = input("An error was detected. DMake will stop. The script directory is : %s.\nDo you want to stop all the running containers? [Y/n]  " % common.tmp_dir)
-            if r.lower() != 'y' and r != "":
-                do_clean = False
+            common.logger.error("""
+PAUSE: An error was detected.
+- check DMake logs above, notably the last step: '- Running <command> @ <service>'
+- you can check the containers status and logs with: 'docker ps -a -f name={name_prefix}'
+- the DMake temporary files are in : {tmp_dir}
+- you can re-run your command with the DMAKE_DEBUG=1 environment variable to see what DMakes really does
+""".format(name_prefix=common.name_prefix, tmp_dir=common.tmp_dir))
+            input("Once you have finished, press <ENTER> to let DMake stop and cleanup the containers and temporary files it created.")
         if do_clean:
             os.system('dmake_clean')
+            if result != 0:
+                common.logger.info("Cleanup finished!")
+        elif common.command == 'run':
+            common.logger.info("Containers started, you can stop them later with 'dmake stop'.")
         sys.exit(result)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -30,7 +30,9 @@ Commands:
     build               Launch the build for the whole repo or, if specified,
                         an app or one of its services.
     run                 Launch the application or only one of its services.
-    stop                Stop the containers lauched with 'dmake run'.
+    stop                Stop the containers started by dmake for the current
+                        repository and branch. Usually by 'dmake run', but can
+                        also be useful to cleanup aborted executions of dmake.
     shell               Run a shell session withing a docker container with
                         the environment set up for a given service.
     deploy              Deploy specified apps and services.


### PR DESCRIPTION
- remove the possibility to skip cleanup: just keep dmake alive while
  error is investigated, then press enter to finish with cleanup
- add multiple suggestions on how to investigate the error
- better dmake run messages, with link to dmake stop