### PR TITLE
Fix insecure string interpolation when dmake pushes git tag after a deployment on jenkins

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -614,7 +614,7 @@ def generate_command_pipeline(file, cmds):
                     write_line("withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: env.DMAKE_JENKINS_HTTP_CREDENTIALS, usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD']]) {")
                     indent_level += 1
                     write_line('try {')
-                    write_line("""  sh("git push --force '%s://${GIT_USERNAME}:${GIT_PASSWORD}@%s' refs/tags/%s")""" % (prefix, host, kwargs['tag']))
+                    write_line("""  sh('git push --force "%s://${GIT_USERNAME}:${GIT_PASSWORD}@%s" refs/tags/%s')""" % (prefix, host, kwargs['tag']))
                     write_line('} catch(error) {')
                     write_line("""  sh('echo "%s"')""" % tag_push_error_msg.replace("'", "\\'"))
                     write_line('}')


### PR DESCRIPTION
See https://jenkins.io/redirect/groovy-string-interpolation
- before it was groovy that injected the git password as string to the
  sh commandline
- now the git password is passed as env var, and it's sh that string
 interpolates

Later we could even use something like https://stackoverflow.com/questions/8536732/can-i-hold-git-credentials-in-environment-variables