### PR TITLE
Various fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ In order to run **DMake**, you will need:
 - Python 3.5+
 - Docker 1.12 or newer; docker 19.03+ with buildkit enabled is **strongly** recommended (see https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds, edit `/etc/docker/daemon.json`)
 - Git 1.8.5 or newer (centos 7 default version 1.8.3 is not compatible)
+- Kubectl 1.18+ when deploying on kubernetes
 
 In order to install **DMake**, use the following:
 
@@ -292,4 +293,3 @@ Or:
 See auto-generated [format documentation](docs/FORMAT.md) and [`dmake.yml` example](docs/EXAMPLE.md).
 
 See also [`dmake --help`](docs/USAGE.md) for command-line interface.
-

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -285,7 +285,7 @@ def find_repo_root(path=os.getcwd()):
 
 def git_get_upstream_branch_remote(branch):
     try:
-        upstream_branch = run_shell_command('git rev-parse --abbrev-ref --symbolic-full-name {}@{{upstream}} --'.format(branch), raise_on_return_code=True)
+        upstream_branch = run_shell_command('git rev-parse --abbrev-ref --symbolic-full-name {}@{{upstream}}'.format(branch), raise_on_return_code=True)
     except ShellError:
         upstream_branch = None
     if not upstream_branch:

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -13,7 +13,7 @@ import uuid
 
 # Set logger
 logger = logging.getLogger("dmake")
-logger.setLevel(logging.INFO) #TODO configurable
+logger.setLevel(os.environ.get('DMAKE_LOGLEVEL', 'INFO').upper())
 logger.addHandler(logging.StreamHandler())
 
 ###############################################################################

--- a/dmake/common.py
+++ b/dmake/common.py
@@ -498,11 +498,6 @@ def init(_options, early_exit=False):
     if 'branch' in options and options.branch:
         branch = options.branch
 
-    # Modify command if (is_pr && !is_local)
-    # TODO remove later: has beend moved to Jenkinsfile instead
-    if is_pr and not is_local and command == "deploy":
-        command = "test"
-
     # Find git info
     repo = ''
     repo_url = None

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -1009,10 +1009,8 @@ def make(options, parse_files_only=False):
 
         ordered_build_files = [('Building Base', base),
                                ('Building App', build),
-                               ('Running App', test)]
-
-        if not common.is_pr:
-            ordered_build_files.append(('Deploying', list(deploy)))
+                               ('Running App', test),
+                               ('Deploying', deploy)]
 
     common.logger.info("Here is the plan:")
     # Generate the list of command to run

--- a/dmake/deepobuild.py
+++ b/dmake/deepobuild.py
@@ -831,7 +831,7 @@ class KubernetesDeploySerializer(YAML2PipelineSerializer):
                 k8s_utils.dump_all_str_and_add_metadata(user_manifest_data_str, dmake_generated_labels, dmake_generated_annotations, f)
             # verify the manifest file
             program = 'kubectl'
-            args = ['--context=%s' % context, 'apply', '--dry-run=true', '--validate=true', '--filename=%s' % user_manifest_path]
+            args = ['--context=%s' % context, '--namespace=%s' % namespace, 'apply', '--dry-run=server', '--validate=true', '--filename=%s' % user_manifest_path]
             cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
             try:
                 common.run_shell_command(cmd, raise_on_return_code=True)

--- a/dmake/kubernetes.py
+++ b/dmake/kubernetes.py
@@ -75,7 +75,7 @@ def dump_all_str_and_add_metadata(data_str_or_list_of_str, labels=None, annotati
 
 def generate_from_create(args, name, from_file_args):
     program = 'kubectl'
-    args = ['create'] + args + ['--dry-run=true', '--output=yaml', name] + from_file_args
+    args = ['create'] + args + ['--dry-run=client', '--output=yaml', name] + from_file_args
     cmd = '%s %s' % (program, ' '.join(map(common.wrap_cmd, args)))
     manifest = common.run_shell_command(cmd, raise_on_return_code=True)
     return manifest

--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -51,7 +51,7 @@ echo_title Apply ${SERVICE} to kubernetes cluster ${CONTEXT}:
 # --record=false allows to specify `kubernetes.io/change-cause` annotation from the manifest files
 APPLY_BASE_ARGS=( "${BASE_ARGS[@]}" apply --record=false --output=yaml )
 if [[ "${DMAKE_K8S_DRY_RUN}" == "1" ]]; then
-  APPLY_BASE_ARGS+=( --dry-run )
+  APPLY_BASE_ARGS+=( --dry-run=server )
 fi
 
 # first, non-pruned resources

--- a/test/k8s/dmake.yml
+++ b/test/k8s/dmake.yml
@@ -4,7 +4,7 @@ app_name: dmake-test
 env:
   default:
     variables:
-      K8S_NAMESPACE: foobar
+      K8S_NAMESPACE: ${DMAKE_TEST_K8S_NAMESPACE}
       K8S_FOO: bar
 
 docker:


### PR DESCRIPTION
- Fix jenkins PR kubernetes manifests validation
- Switch to kubectl 1.18+ --dry-run=server when verifying generated kubernetes manifests
- DMAKE_LOGLEVEL env var to configure dmake log level
- git rev-parse doesn't read `--` as expected: remove it