### PR TITLE
Stop hardcoding `main` kubernetes context in dmake tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+Kubernetes tests: they consist in just generating the kubernetes yamls, and validate them against a cluster and namespace (with `kubectl apply --dry-run=server`), all at the dmake plan phase.
+- first, set `DMAKE_TEST_K8S_CONTEXT` and `DMAKE_TEST_K8S_NAMESPACE` environment variables to a working cluster, having 2 namespaces already created: `${DMAKE_TEST_K8S_NAMESPACE}` and `${DMAKE_TEST_K8S_NAMESPACE}-2`
+- finally, run the plan-only part of the deployment of [`./test/k8s/`](./test/k8s/dmake.yml)): `DMAKE_ON_BUILD_SERVER=1 dmake deploy test-k8s --branch=master`
+
+more details:
+- you can debug thins with `DMAKE_LOGLEVEL=DEBUG` and look for `kubectl` calls
+- see [`Jenkinsfile`](./Jenkinsfile#L119-L126) for how it's configured on Jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ node {
       }
       if (params.DMAKE_COMMAND == 'test') {
         echo "First: kubernetes deploy dry-run (just plan deployment on target branch to validate kubernetes manifests templates)"
-        withEnv([" KUBECONFIG=${MINIKUBE_HOME}/kubeconfig", "DMAKE_TEST_K8S_NAMESPACE=dmake-test"]) {
+        withEnv(["KUBECONFIG=${MINIKUBE_HOME}/kubeconfig", "DMAKE_TEST_K8S_CONTEXT=minikube", "DMAKE_TEST_K8S_NAMESPACE=dmake-test"]) {
           sh "kubectl create namespace ${env.DMAKE_TEST_K8S_NAMESPACE} --save-config --dry-run=client -o yaml | kubectl apply -f -"
           sh "kubectl create namespace ${env.DMAKE_TEST_K8S_NAMESPACE}-2 --save-config --dry-run=client -o yaml | kubectl apply -f -"
           sh ". .venv3/bin/activate && ${params.CUSTOM_ENVIRONMENT} DMAKE_SKIP_TESTS=1 dmake deploy ${dmake_with_dependencies} '${params.DMAKE_APP_TO_TEST}' --branch ${params.DEPLOY_BRANCH_TO_TEST}"

--- a/test/k8s/dmake.yml
+++ b/test/k8s/dmake.yml
@@ -4,6 +4,7 @@ app_name: dmake-test
 env:
   default:
     variables:
+      K8S_CONTEXT: ${DMAKE_TEST_K8S_CONTEXT}
       K8S_NAMESPACE: ${DMAKE_TEST_K8S_NAMESPACE}
       K8S_FOO: bar
 
@@ -25,14 +26,14 @@ services:
         - description: "Deploying on Kubernetes: mono manifest"
           branches: [master]
           kubernetes:
-            context: main
+            context: ${K8S_CONTEXT}
             namespace: ${K8S_NAMESPACE}
             manifest:
               template: deploy/kubernetes-deploy-1.yaml
         - description: "Deploying on Kubernetes: multi manifest"
           branches: [master]
           kubernetes:
-            context: main
+            context: ${K8S_CONTEXT}
             manifests:
               - template: deploy/kubernetes-deploy-2.yaml
                 variables:
@@ -41,7 +42,7 @@ services:
         - description: "Deploying on Kubernetes: other"
           branches: [master]
           kubernetes:
-            context: main
+            context: ${K8S_CONTEXT}
             namespace: ${K8S_NAMESPACE}-2
             config_maps:
               - name: dmake-test-k8s-configmap


### PR DESCRIPTION
- use a new `DMAKE_TEST_K8S_CONTEXT` environment variable
- set it to minikube in Jenkinsfile for dmake own tests where we
  already used minikube
- added a CONTRIBUTING doc to explain this setup to test (part of) the
  kubernetes deployment