### PR TITLE
Abort old builds for some branches

### DIFF
--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -61,6 +61,11 @@ try {
     default_abort_old_builds_on_pr=true
 }
 
+try {
+    default_abort_old_builds_on_branches=DEFAULT_ABORT_OLD_BUILDS_ON_BRANCHES
+} catch (e) {
+    default_abort_old_builds_on_branches="" // empty list: disabled
+}
 
 try {
     default_pipeline_triggers=DEFAULT_PIPELINE_TRIGGERS
@@ -101,10 +106,20 @@ properties([
         booleanParam(name: 'ABORT_OLD_BUILDS_ON_PR',
                      defaultValue: default_abort_old_builds_on_pr,
                      description: 'Abort old builds when job is for a PR.'),
+        string(name: 'ABORT_OLD_BUILDS_ON_BRANCHES',
+               defaultValue: default_abort_old_builds_on_branches,
+               description: 'Abort old builds for a branches, comma separated list.'),
     ]),
     pipelineTriggers(default_pipeline_triggers)
 ])
 
+// Abort old builds for a branches
+// from https://issues.jenkins.io/browse/JENKINS-43353?focusedCommentId=395851&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-395851
+if (env.BRANCH_NAME in params.default_abort_old_builds_on_branches.split(',')) {
+    def buildNumber = env.BUILD_NUMBER as int
+    if (buildNumber > 1) milestone(buildNumber - 1)
+    milestone ordinal: buildNumber, label: 'Abort old builds'
+}
 
 // Abort old builds for PRs
 // from https://issues.jenkins.io/browse/JENKINS-43353?focusedCommentId=395851&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-395851

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -64,7 +64,7 @@ try {
 try {
     default_abort_old_builds_on_branches=DEFAULT_ABORT_OLD_BUILDS_ON_BRANCHES
 } catch (e) {
-    default_abort_old_builds_on_branches="" // empty list: disabled
+    default_abort_old_builds_on_branches='' // empty list: disabled
 }
 
 try {
@@ -108,23 +108,16 @@ properties([
                      description: 'Abort old builds when job is for a PR.'),
         string(name: 'ABORT_OLD_BUILDS_ON_BRANCHES',
                defaultValue: default_abort_old_builds_on_branches,
-               description: 'Abort old builds for a branches, comma separated list.'),
+               description: 'Abort old builds for these branches, comma separated list.'),
     ]),
     pipelineTriggers(default_pipeline_triggers)
 ])
 
-// Abort old builds for a branches
-// from https://issues.jenkins.io/browse/JENKINS-43353?focusedCommentId=395851&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-395851
-if (env.BRANCH_NAME in params.default_abort_old_builds_on_branches.split(',')) {
-    def buildNumber = env.BUILD_NUMBER as int
-    if (buildNumber > 1) milestone(buildNumber - 1)
-    milestone ordinal: buildNumber, label: 'Abort old builds'
-}
 
-// Abort old builds for PRs
+// Abort old builds for PRs and branches
 // from https://issues.jenkins.io/browse/JENKINS-43353?focusedCommentId=395851&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-395851
 def is_pr = !!env.CHANGE_BRANCH  // For PRs Jenkins will give the source branch name
-if (is_pr && params.ABORT_OLD_BUILDS_ON_PR) {
+if ((is_pr && params.ABORT_OLD_BUILDS_ON_PR) || (env.BRANCH_NAME in params.ABORT_OLD_BUILDS_ON_BRANCHES.split(','))) {
   def buildNumber = env.BUILD_NUMBER as int
   if (buildNumber > 1) milestone(buildNumber - 1)
   milestone ordinal: buildNumber, label: 'Abort old builds'


### PR DESCRIPTION
## Description
Abort old builds on Jenkins jobs for some branches.

This follows up on #485.

What it does:

- Abort all previous builds for branches present in the comma separated list defined by `DEFAULT_ABORT_OLD_BUILDS_ON_BRANCHES`.
- It can be deactivated if the `DEFAULT_ABORT_OLD_BUILDS_ON_BRANCHES` list is empty (the default).