### PR TITLE
Skip waiting for kubernetes Deployments with `dmake.deepomatic.com/wait: 'false'` label

### DIFF
--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -76,9 +76,9 @@ if [[ "${DMAKE_K8S_DRY_RUN}" == "1" ]]; then
   exit
 fi
 
-echo_title Rollout status for ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
+echo_title Wait rollout for ${SERVICE} Deployment on kubernetes cluster ${CONTEXT}:
 
-DEPLOYMENTS=( $(kubectl "${BASE_ARGS[@]}" get deployment --selector=dmake.deepomatic.com/service=${SERVICE} --output=jsonpath={.items..metadata.name}) )
+DEPLOYMENTS=( $(kubectl "${BASE_ARGS[@]}" get deployment --selector=dmake.deepomatic.com/service=${SERVICE},dmake.deepomatic.com/wait!=false --output=jsonpath={.items..metadata.name}) )
 for DEPLOYMENT in ${DEPLOYMENTS[@]}; do
   ROLLOUT_STATUS_ARGS=( "${BASE_ARGS[@]}" rollout status --watch=true deployment/${DEPLOYMENT} )
   echo kubectl "${ROLLOUT_STATUS_ARGS[@]}"


### PR DESCRIPTION
closes #527

kubernetes Deployments with `dmake.deepomatic.com/wait: 'false'` labels are not waited for.

Remarks:
- all other values, or missing key, are interpreted as `true`: dmake waits for them after the `kubectl apply`, as before
- all deployed kubernetes resources are still resumed at the end of the deployment with the `kubectl get -f xxx`