### PR TITLE
Support waiting for Argo Rollouts kubernets kinds like we do for native Deployments

### DIFF
--- a/dmake/utils/dmake_deploy_kubernetes
+++ b/dmake/utils/dmake_deploy_kubernetes
@@ -85,6 +85,24 @@ for DEPLOYMENT in ${DEPLOYMENTS[@]}; do
   ${KUBECTL[@]} "${ROLLOUT_STATUS_ARGS[@]}"
 done
 
+echo_title Wait rollout for ${SERVICE} Rollout on kubernetes cluster ${CONTEXT}:
+
+ROLLOUTS=( $(kubectl "${BASE_ARGS[@]}" get rollouts --selector=dmake.deepomatic.com/service=${SERVICE},dmake.deepomatic.com/wait!=false --output=jsonpath={.items..metadata.name}) )
+if [ -x "$(command -v kubectl-argo-rollouts)" ]; then
+  for ROLLOUT in ${ROLLOUTS[@]}; do
+    ROLLOUT_STATUS_ARGS=( argo rollouts "${BASE_ARGS[@]}" status --watch=true ${ROLLOUT} )
+    echo kubectl "${ROLLOUT_STATUS_ARGS[@]}"
+    ${KUBECTL[@]} "${ROLLOUT_STATUS_ARGS[@]}"
+  done
+else
+  echo "WARNING: missing 'kubectl-argo-rollouts' command, cannot properly wait on Argo Rollout. Will just 'get rollouts', not wait on completion..."
+  for ROLLOUT in ${ROLLOUTS[@]}; do
+    ROLLOUT_GET_ARGS=( "${BASE_ARGS[@]}" get rollout/${ROLLOUT} )
+    echo kubectl "${ROLLOUT_GET_ARGS[@]}"
+    ${KUBECTL[@]} "${ROLLOUT_GET_ARGS[@]}"
+  done
+fi
+
 echo_title New state of ${SERVICE} on kubernetes cluster ${CONTEXT}:
 GET_ARGS=( "${BASE_ARGS[@]}" get --output=wide "${FILES_NO_PRUNING_ARGS[@]}" "${FILES_ARGS[@]}" )
 echo kubectl "${GET_ARGS[@]}"


### PR DESCRIPTION
closes #529

It uses the `kubectl-argo-rollouts status` command, which may not be available.
If it's not available: warn about it and just run `kubectl get`.

Also supports the recent #528 skip wait (useful for manual promotion)