### PR TITLE
Add new dmake arg for Jenkinsfile control: dmake_arg_deploy_region

### DIFF
--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -162,6 +162,18 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
     }
 
     echo "Now really running dmake"
-    sh "${params.CUSTOM_ENVIRONMENT} python3 \$(which dmake) ${dmake_command} ${dmake_with_dependencies} '${params.DMAKE_APP}'"
+
+    def dmake_extra_args_str = ''
+    def _dmake_arg_deploy_region = null
+    try {
+        _dmake_arg_deploy_region = dmake_arg_deploy_region
+    } catch (e) {}
+    if (_dmake_arg_deploy_region) {
+        assert !is_pr : '"dmake_arg_deploy_region" not (yet) supported for PR builds'
+        echo "Executing for deploy region '${_dmake_arg_deploy_region}'"
+        dmake_extra_args_str = "--branch=${env.BRANCH_NAME}-${_dmake_arg_deploy_region}"
+    }
+
+    sh "${params.CUSTOM_ENVIRONMENT} python3 \$(which dmake) ${dmake_command} ${dmake_with_dependencies} '${params.DMAKE_APP}' ${dmake_extra_args_str}"
     load 'DMakefile'
 }


### PR DESCRIPTION
related to IN-126

When set (from a new Jenkinsfile.<deploy_region>), dmake is called with `--branch=<the_actual_gitbranch>-<deploy_region>`, using the 'environment branch' suffix as a ~deployment profile for different regions.

dmake Jenkinsfile entrypoint previously supported:
- `DEFAULT_DMAKE_*` groovy variables to change the default job parameters values
- `OVERRIDE_DMAKE_*` groovy variables to override parameters (hackish)

This introduces a new kind:
- `dmake_arg_*` groovy variables to pass dmake arguments which are not exposed as job parameters

This is not (yet) supported for Jenkins PR builds as we don't need it, and extra care would need to be taken notably for the kubernetes manifest pre-run test.

This is easy when limited to deployment branch jobs: it's for `env.BRANCH_NAME`.