### PR TITLE
Support docker image tag customization with environment variables

### DIFF
--- a/docs/EXAMPLE.md
+++ b/docs/EXAMPLE.md
@@ -66,7 +66,7 @@ services:
         source_directories_additional_contexts:
           - ../web
         check_private: true
-        tag: Some string
+        tag: ${_BRANCH_SANITIZED_FOR_DOCKER}-${_BUILD_ID_OR_LATEST}${_VARIANT_SUFFIX}
         workdir: some/dir/example
         copy_directories:
           - some/dir/example

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -100,7 +100,7 @@
                     - an array of strings
                 - **source_directories_additional_contexts** *(array\<string\>, default = `[]`)*: NOT RECOMMENDED. Additional source directories contexts for changed services auto detection in case of build context going outside of the dmake.yml directory.
                 - **check_private** *(boolean, default = `True`)*: Check that the docker repository is private before pushing the image.
-                - **tag** *(string)*: Tag of the docker image to build. By default it will be '[{:variant}-]{:branch_name}-{:build_id}', sanitized and made unique with a hash suffix if needed.
+                - **tag** *(string, default = `${_BRANCH_SANITIZED_FOR_DOCKER}-${_BUILD_ID_OR_LATEST}${_VARIANT_SUFFIX}`)*: Tag of the docker image to build (with extra environment variables available only for this field: prefixed by '_').
                 - **workdir** *(directory path)*: Working directory of the produced docker file, must be an existing directory. By default it will be directory of the dmake file.
                 - **copy_directories** *(array\<directory path\>, default = `[]`)*: Directories to copy in the docker image.
                 - **install_script** *(file path)*: The install script (will be run in the docker). It has to be executable.
@@ -113,7 +113,7 @@
                     - an array of strings
                 - **source_directories_additional_contexts** *(array\<string\>, default = `[]`)*: NOT RECOMMENDED. Additional source directories contexts for changed services auto detection in case of build context going outside of the dmake.yml directory.
                 - **check_private** *(boolean, default = `True`)*: Check that the docker repository is private before pushing the image.
-                - **tag** *(string)*: Tag of the docker image to build. By default it will be '[{:variant}-]{:branch_name}-{:build_id}', sanitized and made unique with a hash suffix if needed.
+                - **tag** *(string, default = `${_BRANCH_SANITIZED_FOR_DOCKER}-${_BUILD_ID_OR_LATEST}${_VARIANT_SUFFIX}`)*: Tag of the docker image to build (with extra environment variables available only for this field: prefixed by '_').
                 - **build** *(object)*: Docker build options for service built using user-provided Dockerfile (ignore `.build.commands`), like in Docker Compose files.`. It must be an object with the following fields:
                     - **context** *(directory path)*: Docker build context directory.
                     - **dockerfile** *(string)*: Alternate Dockerfile, relative path to `context` directory.


### PR DESCRIPTION
closes #526

Add special env vars prefixed with `_` just for this tag name specification, so we can easily reproduce the previous behavior: `${_BRANCH_SANITIZED_FOR_DOCKER}-${_BUILD_ID_OR_LATEST}${_VARIANT_SUFFIX}`
=> it's the new default.
=> Actual default generated value doesn't change.