### PR TITLE
Ignore DMAKE_WITH_DEPENDENCIES when it's not relevant: when DMAKE_COMMAND=build

### DIFF
--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -182,7 +182,11 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
         }
     } catch (e) {}
 
-    dmake_with_dependencies = params.DMAKE_WITH_DEPENDENCIES ? '' : '--standalone'
+    dmake_with_dependencies = params.DMAKE_WITH_DEPENDENCIES ? '--dependencies' : '--standalone'
+    if (dmake_command == 'build') {
+        // no dependencies supported for 'dmake build'
+        dmake_with_dependencies = ''
+    }
 
 
     // really: if PR and command >= test (but it's hard to test, and is currently equivalent to '== test')


### PR DESCRIPTION
It's especially useful when projects set DEFAULT_DMAKE_WITH_DEPENDENCIES=false: the problem was hidden with the default default: --dependencies was implicit.

Also make dependencies explicit now.

No other jenkins-supported commands reject the `--dependencies` flag.