### PR TITLE
Explicit DMAKE_SKIP_TESTS=1 in dmake call build logs on jenkins

### DIFF
--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -210,6 +210,6 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
         dmake_extra_args_str = "--branch=${env.BRANCH_NAME}-${_dmake_arg_deploy_region}"
     }
 
-    sh "${params.CUSTOM_ENVIRONMENT} python3 \$(which dmake) ${dmake_command} ${dmake_with_dependencies} '${params.DMAKE_APP}' ${dmake_extra_args_str}"
+    sh "${params.CUSTOM_ENVIRONMENT} ${params.DMAKE_SKIP_TESTS?"DMAKE_SKIP_TESTS=1":""} python3 \$(which dmake) ${dmake_command} ${dmake_with_dependencies} '${params.DMAKE_APP}' ${dmake_extra_args_str}"
     load 'DMakefile'
 }


### PR DESCRIPTION
Previously the DMAKE_SKIP_TESTS parameter was implicitly passed to the `dmake` process thanks to jenkins exposing all job parameters also as environment variables.
This makes things harder to debug when looking at the actual dmake command.
This is a frequent enough case to improve it.