### PR TITLE
Fix jenkinsfile build with deploy region

### DIFF
--- a/dmake/cli.py
+++ b/dmake/cli.py
@@ -73,7 +73,7 @@ parser_shell.add_argument("-c", '--command', help="Pass to `docker run` specifie
 add_argument([parser_shell, parser_run, parser_test, parser_deploy],
              "-d", "--dependencies", "--no-dependencies", "-s", "--standalone", required=False, default=True, dest='with_dependencies', action=common.DependenciesBooleanAction,
              help="These options control if dependencies are run/tested/deployed. By default, the service is run/tested/deployed alongside its dependencies (service and link dependencies), recursively.")
-add_argument([parser_shell, parser_run, parser_deploy, parser_stop], "-b", "--branch", required=False, default=None, help="Overwrite the git branch name used to select the dmake environment")
+add_argument([parser_shell, parser_run, parser_test, parser_deploy, parser_stop], "-b", "--branch", required=False, default=None, help="Overwrite the git branch name used to select the dmake environment")
 
 parser_run.add_argument("--docker-links-volumes-persistence", "--no-docker-links-volumes-persistence", required=False, default=False, dest='with_docker_links_volumes_persistence', action=common.FlagBooleanAction, help="Control persistence of docker-links volumes (default: non-persistent (for dmake run)).")
 

--- a/dmake/templates/jenkins/Jenkinsfile
+++ b/dmake/templates/jenkins/Jenkinsfile
@@ -204,7 +204,7 @@ sshagent (credentials: (env.DMAKE_JENKINS_SSH_AGENT_CREDENTIALS ?
     try {
         _dmake_arg_deploy_region = dmake_arg_deploy_region
     } catch (e) {}
-    if (_dmake_arg_deploy_region) {
+    if (_dmake_arg_deploy_region && dmake_command != 'build') {
         assert !is_pr : '"dmake_arg_deploy_region" not (yet) supported for PR builds'
         echo "Executing for deploy region '${_dmake_arg_deploy_region}'"
         dmake_extra_args_str = "--branch=${env.BRANCH_NAME}-${_dmake_arg_deploy_region}"


### PR DESCRIPTION
### dmake test should also support --branch override

later, tests should be independent of ~deployment environment, but for
now they are not.

### fix dmake build with dmake_arg_deploy_region on Jenkins

- dmake jenkinsfile supports only build, test and deploy commands
- dmake build does not support --branch override: it wouldn't make
  sense: builds are independent of environments

now: dmake jenkinsfile ignores dmake_arg_deploy_region if (actual)
dmake command is `build`.