### PR TITLE
Support new OCI image index content type to get docker image digest from registry (content digest)

### DIFF
--- a/dmake/test_docker_registry.py
+++ b/dmake/test_docker_registry.py
@@ -1,0 +1,10 @@
+import pytest
+
+from dmake.docker_registry import get_image_digest
+
+@pytest.mark.parametrize("image", [
+    'ubuntu:12.04',  # available only via old manifest: application/vnd.docker.distribution.manifest.v2+json
+    'ubuntu:20.04',  # available only via new manifest: application/vnd.oci.image.index.v1+json
+])
+def test_image_digest(image):
+    assert get_image_digest(image) != ""


### PR DESCRIPTION
- ubuntu:20.04 is now only available with new 'application/vnd.oci.image.index.v1+json'
- ubuntu:12.04 is only available with old 'application/vnd.docker.distribution.manifest.v2+json' (and should hopefully stay that way in the future, for tests stability)
- asking only the new oci.image.index triggers an implicit fallback to 'application/vnd.docker.distribution.manifest.v1+prettyjws' for old images, with a different digest, we don't want that (we want digest stability for base image cache)
- `Docker-Content-Digest` header is still a valid digest with the new content type

=> ask both content types, priority to new one.

Added a quick unit test testing get_image_digest on both old and new content-types (hopefully it should stay stable on docker hub side; if it changes, we should adapt it).

Manually tested test failures when removing either of the accepted_content_types.