### PR TITLE
Bump kubernetes client version to 22.x

### DIFF
--- a/dmake/utils/dmake_deploy_k8s_cd
+++ b/dmake/utils/dmake_deploy_k8s_cd
@@ -38,7 +38,6 @@ selectors = sys.argv[8]
 WAIT_POLL_INTERVAL = 1  # seconds
 PARALLEL_UPDATE_THREAD_POOL_SIZE = 10  # number of Deployments being updated in parallel
 
-os.system('kubectl get nodes')  # refresh auth token for kubectl, otherwise next line might fail
 kubernetes.config.load_kube_config(context=context)
 
 if os.getenv('DMAKE_DEBUG') == '1':

--- a/dmake/utils/dmake_deploy_k8s_cd
+++ b/dmake/utils/dmake_deploy_k8s_cd
@@ -41,7 +41,7 @@ PARALLEL_UPDATE_THREAD_POOL_SIZE = 10  # number of Deployments being updated in 
 kubernetes.config.load_kube_config(context=context)
 
 if os.getenv('DMAKE_DEBUG') == '1':
-    configuration = kubernetes.client.Configuration()
+    configuration = kubernetes.client.Configuration.get_default_copy()
     configuration.debug = True
     kubernetes.client.Configuration.set_default(configuration)
     logger.setLevel(logging.DEBUG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ruamel.yaml==0.16.10
-kubernetes==11.0.0
+kubernetes==22.6.0
 requests-oauthlib==1.3.0
 inquirer==2.6.3
 PyGithub==1.51


### PR DESCRIPTION
Bump kubernetes client version to [22.6.0](
https://github.com/kubernetes-client/python/blob/release-22.0/CHANGELOG.md)

DMAKE_DEBUG=1 is broken: missing kubernetes debug logs after first request, cf https://github.com/kubernetes-client/python/issues/1799