### PR TITLE
Add DMAKE_DOCKER_RUN_EXTRA_ARGS env var support

### DIFF
--- a/dmake/utils/dmake_run_docker
+++ b/dmake/utils/dmake_run_docker
@@ -44,7 +44,7 @@ if [ ! -z "${TMP_DIR}" ]; then
     echo ${NAME} >> ${TMP_DIR}/containers_to_remove.txt
 fi
 
-DOCKER_RUN_ARGS=( )
+DOCKER_RUN_ARGS=( $DMAKE_DOCKER_RUN_EXTRA_ARGS )  # volontarily non-escaped env var to allow passing mutiple extra args via one env var (bash array vars cannot be passed via env vars); limitations: split on spaces will break any tentative of space escaping: space chars are not supported
 
 # support some GPU modes using nvidia docker v2
 if [[ "${DMAKE_DOCKER_RUN_WITH_GPU}" == 'yes' ]]; then


### PR DESCRIPTION
Sometimes it's useful to add more arguments to the docker run command.

Fo example:
DMAKE_DOCKER_RUN_EXTRA_ARGS=--add-host=host.docker.internal:host-gateway so the containers can talk to a service exposed on the host. (use `docker network inspect bridge | jq -r .[].IPAM.Config[].Gateway` to get the docker IP on host side to not expose to your whole LAN)

Implementation details:
Since bash array vars cannot be passed via env vars, we limit our support (no space inside arguments), and rely on the bash word split on spaces with no variable quoting.
volontarily non-escaped env var to allow passing mutiple extra args via one env var (bash array vars cannot be passed via env vars); limitations: split on spaces will break any tentative of space escaping: space chars are not supported.

how to pass multiple arguments:
DMAKE_DOCKER_RUN_EXTRA_ARGS='--arg1=1 --arg2=2'