### PR TITLE
Fix escaped string for python3.12

### DIFF
--- a/dmake/utils/dmake_replace_vars
+++ b/dmake/utils/dmake_replace_vars
@@ -33,7 +33,7 @@ else:
 
 data=open(input_file).read()
 
-lvars = re.findall('\${([A-Za-z\-_]+)}', data)
+lvars = re.findall(r'\${([A-Za-z\-_]+)}', data)
 for var in lvars:
     if var in os.environ:
         value = os.environ[var]


### PR DESCRIPTION
Using dmake with python 3.12 fails with:

```
dmake.common.ShellError: /Users/vincent/deepomatic/dmake/dmake/utils/dmake_replace_vars:36: SyntaxWarning: invalid escape sequence '\$'
  lvars = re.findall('\${([A-Za-z\-_]+)}', data)
```

This PR fixes it.