### PR TITLE
Use supported coverage plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,8 +109,7 @@ node {
           sh ". .venv3/bin/activate && pytest --numprocesses=4 -vv --color=yes --junit-xml=junit.xml --junit-prefix=python3 --cov=dmake/ --cov-report=xml:coverage.xml --cov-report html:cover/"
         } finally {
           junit keepLongStdio: true, testResults: 'junit.xml'
-          step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'coverage.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])
-          publishCoverage adapters: [coberturaAdapter(mergeToOneReport: true, path: 'coverage.xml')], calculateDiffForChangeRequests: true, sourceFileResolver: sourceFiles('NEVER_STORE')
+          recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']], qualityGates: [[metric: 'LINE', baseline: 'PROJECT_DELTA', criticality: 'NOTE']], sourceCodeRetention: 'NEVER')
           publishHTML(target: [allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'cover', reportFiles: 'index.html', reportName: 'dmake HTML coverage report'])
         }
       }

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -666,8 +666,7 @@ def generate_command_pipeline(file, cmds):
     if emit_cobertura:
         write_line("try {")
         indent_level += 1
-        write_line("step([$class: 'CoberturaPublisher', autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: '%s/**/*.xml', failUnhealthy: false, failUnstable: false, maxNumberOfBuilds: 0, onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false])" % (cobertura_tests_results_dir))
-        write_line("publishCoverage adapters: [coberturaAdapter(mergeToOneReport: false, path: '%s/**/*.xml')], calculateDiffForChangeRequests: true, sourceFileResolver: sourceFiles('NEVER_STORE')" % (cobertura_tests_results_dir))
+        write_line("recordCoverage(tools: [[parser: 'COBERTURA', pattern: '%s/**/*.xml']], qualityGates: [[metric: 'LINE', baseline: 'PROJECT_DELTA', criticality: 'NOTE']], sourceCodeRetention: 'NEVER')" % (cobertura_tests_results_dir))
         write_line('''sh('rm -rf "%s"')''' % cobertura_tests_results_dir)
         indent_level -= 1
         write_line("} catch (error) {")

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,7 +6,7 @@ usage: dmake [-h] [--debug-graph] [--debug-graph-and-exit]
              {test,build,run,stop,shell,deploy,release,graph,generate-doc,completion}
              ...
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug-graph         Generate dmake steps DOT graph for debug purposes.
   --debug-graph-and-exit


### PR DESCRIPTION
The [Code Coverage Plugin](https://plugins.jenkins.io/code-coverage-api/) is deprecated and does not work anymore.

We follow the instruction of the linked page and replace `publishCoverage` by `recordCoverage`.

This has been tested on Jenkins, it leads to the apparition of 2 menu entries below "Test result", that were not present before this PR:
<img width="266" alt="Capture d’écran 2024-07-21 à 20 56 54" src="https://github.com/user-attachments/assets/192d6d2b-9e41-4cd2-95f3-fe10da79a51e">

The "Coverage report" looks like this:
<img width="1298" alt="Capture d’écran 2024-07-21 à 20 58 52" src="https://github.com/user-attachments/assets/11bd9981-edf0-46a8-b6ad-33eeb60c2880">

