### PR TITLE
Fix cobertura coverage collection

### DIFF
--- a/dmake/core.py
+++ b/dmake/core.py
@@ -665,14 +665,8 @@ def generate_command_pipeline(file, cmds):
     indent_level += 1
 
     if emit_cobertura:
-        write_line("try {")
-        indent_level += 1
         write_line("recordCoverage(tools: [[parser: 'COBERTURA', pattern: '%s/**/*.xml']], qualityGates: [[metric: 'LINE', baseline: 'PROJECT_DELTA', criticality: 'NOTE']], sourceCodeRetention: 'NEVER')" % (cobertura_tests_results_dir))
         write_line('''sh('rm -rf "%s"')''' % cobertura_tests_results_dir)
-        indent_level -= 1
-        write_line("} catch (error) {")
-        write_line("  dmake_echo 'Late cobertura_report test result collection failed, it may be because the test steps were not reached (earlier error: check logs/steps above/before), or because the cobertura_report is misconfigured (check the path config). Error message: ${error}'")
-        write_line("}")
 
     write_line('sh("dmake_clean")')
     indent_level -= 1

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -503,7 +503,8 @@ def generate_command_pipeline(file, cmds):
     write_line('try {')
     indent_level += 1
 
-    cobertura_tests_results_dir = os.path.join(common.relative_cache_dir, 'cobertura_tests_results')
+    # We use one dedicated directory per build to avoid loading results from previous builds
+    cobertura_tests_results_dir = os.path.join(common.relative_cache_dir, 'cobertura_tests_results', str(common.build_id))
     emit_cobertura = False
 
     # checks to generate valid Jenkinsfiles

--- a/dmake/core.py
+++ b/dmake/core.py
@@ -671,7 +671,7 @@ def generate_command_pipeline(file, cmds):
         write_line('''sh('rm -rf "%s"')''' % cobertura_tests_results_dir)
         indent_level -= 1
         write_line("} catch (error) {")
-        write_line("  dmake_echo 'Late cobertura_report test result collection failed, it may be because the test steps were not reached (earlier error: check logs/steps above/before), or because the cobertura_report is misconfigured (check the path config).'")
+        write_line("  dmake_echo 'Late cobertura_report test result collection failed, it may be because the test steps were not reached (earlier error: check logs/steps above/before), or because the cobertura_report is misconfigured (check the path config). Error message: ${error}'")
         write_line("}")
 
     write_line('sh("dmake_clean")')


### PR DESCRIPTION
Current behavior collects XML cobertura reports from container into a host directory randomly generated, which results in many directories in .dmake/cobertura_tests_results/, not all being from the same build.

For example:
```
jenkins@fce34241e9ef:~/jobs/vesta/branches/master/workspace$ ls -lt .dmake/cobertura_tests_results/
total 140
drwxr-xr-x 3 jenkins jenkins 4096 Jan  2 22:19 db6f4875-a58f-4793-bcda-0a21d6781ff0
...
drwxr-xr-x 3 jenkins jenkins 4096 Dec 26 09:56 8defe87f-9146-45c3-b073-f962de7000ad
```

When generating the report, we look for XML files in `dmake/cobertura_tests_results/**/*.xml`